### PR TITLE
Feat/note staff schema

### DIFF
--- a/lib/gp2rs.py
+++ b/lib/gp2rs.py
@@ -69,6 +69,7 @@ class RsNote:
     tremolo: bool = False
     tap: bool = False
     link_next: bool = False
+    staff: int = -1  # Piano staff: -1=absent, 0=LH/bass clef, 1=RH/treble clef
 
 
 @dataclass
@@ -1021,6 +1022,8 @@ def _build_xml(
             "tap": "1" if n.tap else "0",
             "ignore": "0",
         }
+        if getattr(n, 'staff', -1) != -1:
+            attrs["staff"] = str(n.staff)
         ET.SubElement(notes_el, "note", **attrs)
 
     # Chords

--- a/lib/gp2rs_gpx.py
+++ b/lib/gp2rs_gpx.py
@@ -133,35 +133,15 @@ def _parse_bcfs(bcfs: bytes) -> dict:
 
 
 def _load_gpif(gp_path: str) -> ET.Element:
-    """Load and parse score.gpif from a .gpx (GP6) or .gp (GP7/GP8) file.
-
-    GP6 (.gpx): custom BCFZ/BCFS binary container holding score.gpif.
-    GP7/GP8 (.gp): standard ZIP archive holding Content/score.gpif.
-    Both formats use the same GPIF XML schema inside, so a single parser
-    handles all versions once the outer container is unpacked.
-    """
+    """Load and parse score.gpif from a .gpx file."""
     with open(gp_path, 'rb') as fh:
         raw = fh.read()
-
-    # GP7/GP8: ZIP container (PK magic)
-    if raw[:2] == b'PK':
-        import zipfile
-        import io as _io
-        with zipfile.ZipFile(_io.BytesIO(raw)) as zf:
-            if 'Content/score.gpif' not in zf.namelist():
-                raise ValueError("Content/score.gpif not found in GP7/GP8 ZIP container")
-            return ET.fromstring(zf.read('Content/score.gpif'))
-
-    # GP6 (.gpx): BCFZ compressed or raw BCFS
     if raw[:4] == b'BCFZ':
         bcfs = _decompress_bcfz(raw)
     elif raw[:4] == b'BCFS':
         bcfs = raw
     else:
-        raise ValueError(
-            f"Unrecognised Guitar Pro container (magic: {raw[:4]!r}). "
-            f"Supported: .gpx (GP6, BCFZ/BCFS) and .gp (GP7/GP8, ZIP)."
-        )
+        raise ValueError(f"Not a GPX file (magic: {raw[:4]!r})")
     fs = _parse_bcfs(bcfs)
     if 'score.gpif' not in fs:
         raise ValueError("score.gpif not found in GPX container")
@@ -279,7 +259,6 @@ def _gpif_tracks(root: ET.Element) -> list[dict]:
         midi_channel = 0
         is_drums = False
         if gm is not None:
-            # GP6 (.gpx): <GeneralMidi table="Percussion"><Program>...</Program>
             try: midi_program = int(gm.findtext('Program') or 0)
             except (ValueError, TypeError): pass
             try:
@@ -289,25 +268,6 @@ def _gpif_tracks(root: ET.Element) -> list[dict]:
             except (ValueError, TypeError): pass
             if gm.get('table') == 'Percussion':
                 is_drums = True
-        else:
-            # GP7/GP8 (.gp): <InstrumentSet><Type>drumKit</Type>
-            # and <MidiConnection><PrimaryChannel>9</PrimaryChannel>
-            inst_set = t.find('InstrumentSet')
-            if inst_set is not None:
-                inst_type = (inst_set.findtext('Type') or '').lower()
-                if inst_type == 'drumkit':
-                    is_drums = True
-            midi_conn = t.find('MidiConnection')
-            if midi_conn is not None:
-                try:
-                    ch_text = (midi_conn.findtext('PrimaryChannel') or '').strip()
-                    if ch_text:
-                        ch = int(ch_text)
-                        midi_channel = ch
-                        if ch == 9:
-                            is_drums = True
-                except (ValueError, TypeError):
-                    pass
 
         # String tuning
         string_pitches: list[int] = []
@@ -624,15 +584,13 @@ def list_tracks(gp_path: str) -> list[dict]:
     result = []
     for i, t in enumerate(tracks):
         is_bass = bool(
-            not t['is_drums']  # drums always have low/zero string pitches — must exclude
-            and (
-                (
-                    not t['string_pitches']  # no string tuning = not guitar-family
-                    and 32 <= t['midi_program'] <= 39
-                ) or (
-                    t['string_pitches']
-                    and max(t['string_pitches']) <= 48  # bass top string ≤ C3
-                )
+            (
+                not t['is_drums']
+                and not t['string_pitches']  # no string tuning = not guitar-family
+                and 32 <= t['midi_program'] <= 39
+            ) or (
+                t['string_pitches']
+                and max(t['string_pitches']) <= 48  # bass top string ≤ C3
             )
         )
         is_piano = (
@@ -1339,7 +1297,7 @@ def convert_file(
             if bid != '-1' and bid:
                 bar = bars_by_id.get(bid)
                 if bar is not None:
-                    for vid in bar.findtext('Voices', '').split():
+                    for voice_pos, vid in enumerate(bar.findtext('Voices', '').split()):
                         if vid == '-1':
                             continue
                         voice = voices_dict.get(vid)
@@ -1440,6 +1398,13 @@ def convert_file(
                                         fret=rs_fret,
                                         sustain=sustain,
                                     )
+                                    # Staff assignment for keys/piano (slopsmith staff schema).
+                                    # Derived from voice position as authored in the GP tab —
+                                    # not inferred from pitch — preserving hand crossings exactly.
+                                    # Voice 0 = treble/RH staff (staff=1),
+                                    # Voice 1+ = bass/LH staff (staff=0).
+                                    if is_keys:
+                                        rn.staff = 1 if voice_pos == 0 else 0
 
                                     # Techniques — GPIF stores these as <Property>
                                     # elements (NOT child tags), so the old
@@ -1624,7 +1589,7 @@ def convert_file(
                 if _lh_bid != '-1' and _lh_bid:
                     _lh_bar = bars_by_id.get(_lh_bid)
                     if _lh_bar is not None:
-                        for _lh_vid in _lh_bar.findtext('Voices', '').split():
+                        for _lh_voice_pos, _lh_vid in enumerate(_lh_bar.findtext('Voices', '').split()):
                             if _lh_vid == '-1':
                                 continue
                             _lh_voice = voices_dict.get(_lh_vid)
@@ -1674,6 +1639,8 @@ def convert_file(
                                         fret=_lh_midi % 24,
                                         sustain=_lh_dur if _lh_dur > 0.2 else 0.0,
                                     )
+                                    # Preserve authored voice-position staff assignment.
+                                    _lh_rn.staff = 1 if _lh_voice_pos == 0 else 0
                                     _lh_notes.append(_lh_rn)
                                     _lh_last_per_key[_lh_midi] = _lh_rn
                                 _lh_vt += _lh_dur

--- a/lib/gp2rs_gpx.py
+++ b/lib/gp2rs_gpx.py
@@ -133,15 +133,35 @@ def _parse_bcfs(bcfs: bytes) -> dict:
 
 
 def _load_gpif(gp_path: str) -> ET.Element:
-    """Load and parse score.gpif from a .gpx file."""
+    """Load and parse score.gpif from a .gpx (GP6) or .gp (GP7/GP8) file.
+
+    GP6 (.gpx): custom BCFZ/BCFS binary container holding score.gpif.
+    GP7/GP8 (.gp): standard ZIP archive holding Content/score.gpif.
+    Both formats use the same GPIF XML schema inside, so a single parser
+    handles all versions once the outer container is unpacked.
+    """
     with open(gp_path, 'rb') as fh:
         raw = fh.read()
+
+    # GP7/GP8: ZIP container (PK magic)
+    if raw[:2] == b'PK':
+        import zipfile
+        import io as _io
+        with zipfile.ZipFile(_io.BytesIO(raw)) as zf:
+            if 'Content/score.gpif' not in zf.namelist():
+                raise ValueError("Content/score.gpif not found in GP7/GP8 ZIP container")
+            return ET.fromstring(zf.read('Content/score.gpif'))
+
+    # GP6 (.gpx): BCFZ compressed or raw BCFS
     if raw[:4] == b'BCFZ':
         bcfs = _decompress_bcfz(raw)
     elif raw[:4] == b'BCFS':
         bcfs = raw
     else:
-        raise ValueError(f"Not a GPX file (magic: {raw[:4]!r})")
+        raise ValueError(
+            f"Unrecognised Guitar Pro container (magic: {raw[:4]!r}). "
+            f"Supported: .gpx (GP6, BCFZ/BCFS) and .gp (GP7/GP8, ZIP)."
+        )
     fs = _parse_bcfs(bcfs)
     if 'score.gpif' not in fs:
         raise ValueError("score.gpif not found in GPX container")
@@ -589,7 +609,8 @@ def list_tracks(gp_path: str) -> list[dict]:
                 and not t['string_pitches']  # no string tuning = not guitar-family
                 and 32 <= t['midi_program'] <= 39
             ) or (
-                t['string_pitches']
+                not t['is_drums']  # explicit guard: drums can have low string pitches
+                and t['string_pitches']
                 and max(t['string_pitches']) <= 48  # bass top string ≤ C3
             )
         )
@@ -1400,7 +1421,7 @@ def convert_file(
                                     )
                                     # Staff assignment for keys/piano (slopsmith staff schema).
                                     # Derived from voice position as authored in the GP tab —
-                                    # not inferred from pitch — preserving hand crossings exactly.
+                                    # not inferred from pitch — preserving hand crossings.
                                     # Voice 0 = treble/RH staff (staff=1),
                                     # Voice 1+ = bass/LH staff (staff=0).
                                     if is_keys:
@@ -1589,7 +1610,7 @@ def convert_file(
                 if _lh_bid != '-1' and _lh_bid:
                     _lh_bar = bars_by_id.get(_lh_bid)
                     if _lh_bar is not None:
-                        for _lh_voice_pos, _lh_vid in enumerate(_lh_bar.findtext('Voices', '').split()):
+                        for _lh_vid in _lh_bar.findtext('Voices', '').split():
                             if _lh_vid == '-1':
                                 continue
                             _lh_voice = voices_dict.get(_lh_vid)
@@ -1639,8 +1660,10 @@ def convert_file(
                                         fret=_lh_midi % 24,
                                         sustain=_lh_dur if _lh_dur > 0.2 else 0.0,
                                     )
-                                    # Preserve authored voice-position staff assignment.
-                                    _lh_rn.staff = 1 if _lh_voice_pos == 0 else 0
+                                    # LH track notes are always bass clef (staff=0).
+                                    # The LH track as a whole IS the left hand —
+                                    # voice position within the LH track is irrelevant.
+                                    _lh_rn.staff = 0
                                     _lh_notes.append(_lh_rn)
                                     _lh_last_per_key[_lh_midi] = _lh_rn
                                 _lh_vt += _lh_dur

--- a/lib/song.py
+++ b/lib/song.py
@@ -310,7 +310,7 @@ def note_from_wire(d: dict, time: float | None = None) -> Note:
         right_hand=_wire_int_optional(d.get("rh"), -1),
         pick_direction=_wire_int_optional(d.get("pkd"), -1),
         ignore=bool(d.get("ig", False)),
-        staff=int(d.get("stf", -1)),
+        staff=_wire_int_optional(d.get("stf"), -1),
     )
 
 

--- a/lib/song.py
+++ b/lib/song.py
@@ -37,6 +37,7 @@ class Note:
     right_hand: int = -1
     pick_direction: int = -1
     ignore: bool = False
+    staff: int = -1  # Piano staff: -1=absent, 0=LH/bass clef, 1=RH/treble clef
 
 
 @dataclass
@@ -217,6 +218,8 @@ def note_to_wire(n: Note) -> dict:
         out["pkd"] = n.pick_direction
     if n.ignore:
         out["ig"] = True
+    if n.staff != -1:
+        out["stf"] = n.staff
     return out
 
 
@@ -307,6 +310,7 @@ def note_from_wire(d: dict, time: float | None = None) -> Note:
         right_hand=_wire_int_optional(d.get("rh"), -1),
         pick_direction=_wire_int_optional(d.get("pkd"), -1),
         ignore=bool(d.get("ig", False)),
+        staff=int(d.get("stf", -1)),
     )
 
 
@@ -762,6 +766,7 @@ def _parse_note(n) -> Note:
         right_hand=_int_optional(n, "rightHand", -1),
         pick_direction=_int_optional(n, "pickDirection", -1),
         ignore=_bool(n, "ignore"),
+        staff=_int_optional(n, "staff", -1),
     )
 
 


### PR DESCRIPTION
> _🗂️ Migrated PR. Originally opened by @mogul on 2026-06-18 (was #515). Review history not preserved._

> _Reconstructed from `slopsmith/slopsmith#703` — original PR by @zagatozee. Commits replayed with original authorship onto the current `main`._

Edit schema handling for Piano charts. 

Groundwork for importing various chart styles while keeping authored Left Hand and Right Hand information intact. Useful for higher quality piano charts, difficulty options; being able to more accurately turn on or off LH or RH charts at whim while making it so authored information is retained, rather than replacing it with assumed data based on note location.

If "hands cross over" is properly charted (music.xml, Guitar Pro etc) then this should allow that to be accurately depicted in slopsmith piano charts.

Seperate PR on the "https://github.com/slopsmith/slopsmith-plugin-piano/tree/feat/note-staff-schema" branch will follow in due course (ahem, session limited)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notes now carry explicit staff-position metadata; serialization and XML/wire formats include this attribute when present.

* **Changes**
  * Track/drum detection tightened to rely on GPX/General MIDI channel info; older fallback heuristics removed.
  * Drum and bass classification logic updated.
  * Piano/keyboard voice handling refined so voice positions determine staff assignment and LH notes are marked as bass during merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->