### PR TITLE
fix(v3): topbar stacks above the Songs filter bar (instrument selector dropdown)

### DIFF
--- a/static/v3/shell.js
+++ b/static/v3/shell.js
@@ -145,7 +145,12 @@
     function renderTopbar() {
         const bar = document.getElementById('v3-topbar');
         if (!bar) return;
-        bar.className = 'sticky top-0 z-20 bg-fb-sidebar/80 backdrop-blur';
+        // z-30 (not z-20): the global topbar must stack above per-screen sticky
+        // bars — notably the v3 Songs filter/search bar, which is also
+        // `sticky top-0 z-20 backdrop-blur` and, being later in source order,
+        // otherwise wins the z-index tie and paints over the topbar's instrument
+        // selector / tuner dropdowns (slopsmith#857 regression).
+        bar.className = 'sticky top-0 z-30 bg-fb-sidebar/80 backdrop-blur';
         bar.innerHTML =
             // Row 1 — top utility bar: search.
             '<div class="flex items-center gap-4 px-4 md:px-8 pt-4">' +


### PR DESCRIPTION
> _🗂️ Migrated PR. Originally opened by @mogul on 2026-06-18 (was #519). Review history not preserved._

> _Reconstructed from `slopsmith/slopsmith#871` — original PR by @byrongamatos. Commits replayed with original authorship onto the current `main`._

## Problem
On the v3 Songs screen, clicking the topbar **instrument selector** opens its dropdown *behind* the filter/search bar instead of on top.

## Root cause
The Songs filter/search bar (added in #857) is `sticky top-0 z-20 backdrop-blur` — the same z-index + stacking-context recipe as the global topbar (`static/v3/shell.js`). With both at `z-20` and the filter bar **later in source order**, the filter bar wins the tie and paints over the entire topbar subtree. The instrument dropdown (`data-inst-menu`, `z-50`) only competes *within* the topbar's z-20 stacking context, so it loses to the filter bar.

## Fix
Bump the topbar to `z-30` so it (and its dropdowns) stack above the per-screen filter bar. `.z-30` is already present in the committed `static/tailwind.min.css`, so no Tailwind rebuild is needed (tailwind-fresh CI stays green).

## Verification (headless highway_3d/Playwright)
- **Before:** in the filter-bar/dropdown overlap region the topmost element is the filter bar's `<select>` — dropdown hidden.
- **After:** the topmost element in the same region is the instrument menu; the filter bar remains visible.
- The tuner panel (`#tuner-plugin-ui`) is `fixed z-[1000]` on `document.body` and was already on top — confirmed unaffected.
- Full JS suite: 672/672.

Fixes the regression from #857.

🤖 Generated with [Claude Code](https://claude.com/claude-code)