### PR TITLE
fix(v3): rename "Shop" nav entry to "Unlockables"

### DIFF
--- a/static/v3/progress.js
+++ b/static/v3/progress.js
@@ -146,7 +146,7 @@
             '<div class="text-xs uppercase tracking-wider text-fb-textDim">Decibels</div>' +
             '<div class="text-3xl font-bold text-fb-gold mt-1">' + fmtDb(wallet.balance) + '</div>' +
             '<div class="text-xs text-fb-textDim mt-1">' + fmtDb(wallet.lifetime_db) + ' earned lifetime</div>' +
-            '<button type="button" data-prog-shop class="mt-2 text-sm text-fb-primary hover:text-fb-primaryHi font-medium">Open Shop →</button>' +
+            '<button type="button" data-prog-shop class="mt-2 text-sm text-fb-primary hover:text-fb-primaryHi font-medium">Open Unlockables →</button>' +
             '</div></div>' +
             calibrationCard(st.onboarding) +
             // Paths

--- a/static/v3/shell.js
+++ b/static/v3/shell.js
@@ -24,7 +24,7 @@
     const NAV = [
         { key: 'home',       screen: 'v3-home',          label: 'Home',            group: 'HOME',    icon: 'home' },
         { key: 'progress',   screen: 'v3-progress',      label: 'Progress',        group: 'HOME',    icon: 'trophy' },
-        { key: 'shop',       screen: 'v3-shop',          label: 'Shop',            group: 'HOME',    icon: 'tag' },
+        { key: 'shop',       screen: 'v3-shop',          label: 'Unlockables',     group: 'HOME',    icon: 'tag' },
         { key: 'feedbarcade', screen: 'v3-feedbarcade',   label: 'FeedBarcade',    group: 'HOME',    icon: 'arcade' },
         { key: 'plugins',    screen: 'v3-plugins',       label: 'Plugins',         group: 'HOME',    icon: 'plug' },
         { key: 'settings',   screen: 'settings',         label: 'Settings',        group: 'HOME',    icon: 'gear' },


### PR DESCRIPTION
Renames the user-visible "Shop" nav label (`static/v3/shell.js`) and the matching "Open Shop →" button on the progress page (`static/v3/progress.js`) to "Unlockables". Internal ids (`key:'shop'`, `v3-shop`, `window.v3Shop`) untouched. Admin-merging (CI billing-blocked).