### PR TITLE
fix: 'feed[dB]ack' -> 'fee[dB]ack' in v3 guitar tone source labels

### DIFF
--- a/static/v3/index.html
+++ b/static/v3/index.html
@@ -435,11 +435,11 @@
                             <label for="setting-live-guitar-tone-source" class="text-sm font-medium text-gray-400 mb-2 block">Live guitar tone source</label>
                             <select id="setting-live-guitar-tone-source"
                                 class="bg-dark-700 border border-gray-800 rounded-xl px-3 py-2.5 text-sm text-gray-300 outline-none">
-                                <option value="internal">feed[dB]ack internal tone</option>
+                                <option value="internal">fee[dB]ack internal tone</option>
                                 <option value="external_hardware">External amp / hardware pedalboard</option>
                                 <option value="spark_control_x">Spark LIVE + Spark Control X</option>
                             </select>
-                            <p class="text-xs text-gray-600 mt-1">Choose External/Spark if your guitar tone comes from hardware like Spark LIVE. feed[dB]ack will still score your playing but won&rsquo;t warn that no internal amp tone is loaded.</p>
+                            <p class="text-xs text-gray-600 mt-1">Choose External/Spark if your guitar tone comes from hardware like Spark LIVE. fee[dB]ack will still score your playing but won&rsquo;t warn that no internal amp tone is loaded.</p>
                         </div>
                         <div>
                             <label for="demucs-server-url" class="text-sm font-medium text-gray-400 mb-2 block">Demucs Server (for stem separation)</label>
@@ -736,7 +736,7 @@
                     <span class="v3-pop-label">Guitar tone</span>
                     <select id="player-live-guitar-tone-source"
                         class="v3-pop-select max-w-[210px]">
-                        <option value="internal">feed[dB]ack internal tone</option>
+                        <option value="internal">fee[dB]ack internal tone</option>
                         <option value="external_hardware">External amp / hardware pedalboard</option>
                         <option value="spark_control_x">Spark LIVE + Spark Control X</option>
                     </select>

--- a/static/v3/live-guitar-tone-source.js
+++ b/static/v3/live-guitar-tone-source.js
@@ -19,14 +19,14 @@
     const DEFAULT = SOURCES.INTERNAL;
 
     const LABELS = Object.freeze({
-        [SOURCES.INTERNAL]: 'feed[dB]ack internal tone',
+        [SOURCES.INTERNAL]: 'fee[dB]ack internal tone',
         [SOURCES.EXTERNAL_HARDWARE]: 'External amp / hardware pedalboard',
         [SOURCES.SPARK_CONTROL_X]: 'Spark LIVE + Spark Control X',
     });
 
     const HELP_TEXT =
         'Choose External/Spark if your guitar tone comes from hardware like Spark LIVE. '
-        + 'feed[dB]ack will still score your playing but won\u2019t warn that no internal amp tone is loaded.';
+        + 'fee[dB]ack will still score your playing but won\u2019t warn that no internal amp tone is loaded.';
 
     function normalize(value) {
         if (value === SOURCES.EXTERNAL_HARDWARE || value === SOURCES.SPARK_CONTROL_X) return value;


### PR DESCRIPTION
Fixes an extra 'd' in the fee[dB]ack brand name in the v3 guitar tone source selector labels and help text.

- \static/v3/index.html\: 3 occurrences fixed
- \static/v3/live-guitar-tone-source.js\: 2 occurrences fixed

Closes #...