### PR TITLE
feat(highway-2d): render unpitched slides (slu)

### DIFF
--- a/static/highway.js
+++ b/static/highway.js
@@ -1444,7 +1444,8 @@ function createHighway() {
         const isPinchHarmonic = opts?.hp || false;
         const isChord = opts?.chord || false;
         const bend = opts?.bn || 0;
-        const slide = opts?.sl || -1;
+        const slide = opts?.sl ?? -1;  // pitched slide-to fret (-1 = none; 0 = slide to open)
+        const slu = opts?.slu ?? -1;   // unpitched slide-to fret (-1 = none)
         const hammerOn = opts?.ho || false;
         const pullOff = opts?.po || false;
         const tap = opts?.tp || false;
@@ -1637,20 +1638,29 @@ function createHighway() {
 
         if (sz < 14) return;  // Skip small technique labels
 
-        // Slide indicator (diagonal arrow)
-        if (slide >= 0) {
-            const dir = slide > fret ? -1 : 1;  // arrow direction (up or down the neck); mirror handles lefty
+        // Slide indicator (diagonal arrow). Pitched (sl) draws a solid arrow to
+        // the target fret; unpitched (slu) draws a dashed diagonal with no
+        // arrowhead (no definite target pitch). The two are mutually exclusive
+        // in the data; the 3D highway makes the same pitched/unpitched split.
+        if (slide >= 0 || slu >= 0) {
+            const pitched = slide >= 0;
+            const target = pitched ? slide : slu;
+            const dir = target > fret ? -1 : 1;  // up or down the neck; mirror handles lefty
             ctx.strokeStyle = '#fff';
             ctx.lineWidth = Math.max(2, sz / 10);
+            if (!pitched) ctx.setLineDash([Math.max(2, sz / 8), Math.max(2, sz / 8)]);
             ctx.beginPath();
             ctx.moveTo(x - sz * 0.3, y + dir * sz * 0.3);
             ctx.lineTo(x + sz * 0.3, y - dir * sz * 0.3);
             ctx.stroke();
-            // Arrowhead
-            ctx.beginPath();
-            ctx.moveTo(x + sz * 0.3, y - dir * sz * 0.3);
-            ctx.lineTo(x + sz * 0.15, y - dir * sz * 0.15);
-            ctx.stroke();
+            if (!pitched) ctx.setLineDash([]);
+            // Arrowhead only for a pitched slide (definite target pitch).
+            if (pitched) {
+                ctx.beginPath();
+                ctx.moveTo(x + sz * 0.3, y - dir * sz * 0.3);
+                ctx.lineTo(x + sz * 0.15, y - dir * sz * 0.15);
+                ctx.stroke();
+            }
         }
 
         // H/P/T label above note


### PR DESCRIPTION
The 2D highway rendered pitched slides (`sl`) but **ignored unpitched slides (`slu`)** — `drawNote` read only `opts.sl`, and there was no `slu` anywhere in `static/highway.js`. The 3D highway already renders both (`slideTrailEnd`). This brings the 2D highway to parity (the last item in epic #334's render-parity slice).

## Change
- `drawNote` now draws `slu` as a **dashed diagonal, no arrowhead** (no definite target pitch), keeping the solid arrow + arrowhead for pitched `sl`. The two are mutually exclusive in the data; the 3D highway makes the same split.
- Chord notes flow through the same `drawNote`, so chord-note unpitched slides are covered too.
- **Latent fix (review):** `opts?.sl || -1` discarded a pitched **slide-to-open** (`sl: 0`); now `?? -1` preserves fret-0 targets and keeps pitched precedence over unpitched.

## Review
Codex: **no P1/P2**. Confirmed `setLineDash` is reset on all paths (no dash-state leak), no pitched-slide regression. The one P3 (the `sl: 0` asymmetry) is fixed above. `node --check` clean.

Render-only; the editor already authors `slu` (`promptSlideUnpitch`).

Closes #336. Part of got-feedback/feedback#334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)