### PR TITLE
feat(highway): render chord harmony fn.rn + voicing on 2D + 3D (§6.3.1, §6.6)

### DIFF
--- a/lib/song.py
+++ b/lib/song.py
@@ -65,6 +65,9 @@ class ChordTemplate:
     frets: list[int]
     display_name: str = ""
     arpeggio: bool = False
+    # Harmony annotation (§6.6) — key-independent voicing type, e.g. "open",
+    # "triad", "shell", "drop2", "barre". Display/teaching only, never grading.
+    voicing: str = ""
 
 
 @dataclass
@@ -73,6 +76,10 @@ class Chord:
     chord_id: int
     notes: list[Note] = field(default_factory=list)
     high_density: bool = False
+    # Harmony annotation (§6.3.1) — key-dependent harmonic function on the chord
+    # INSTANCE: {rn: str, q: str, deg: int 0..11}. All three keys required when
+    # present (see _validate_fn). Display/teaching only, never grading.
+    fn: dict | None = None
 
 
 @dataclass
@@ -268,12 +275,19 @@ def chord_note_to_wire(cn: Note) -> dict:
 
 
 def chord_to_wire(c: Chord) -> dict:
-    return {
+    out = {
         "t": round(c.time, 3),
         "id": c.chord_id,
         "hd": c.high_density,
         "notes": [chord_note_to_wire(cn) for cn in c.notes],
     }
+    # Harmony function (§6.3.1) — default-omitted, mirroring bend `bnv`. Re-validate
+    # on emit (not just decode) so a directly-constructed Chord can't put a partial
+    # or out-of-range fn on the wire, which would fail the schema's required-keys rule.
+    fn = _validate_fn(c.fn)
+    if fn:
+        out["fn"] = fn
+    return out
 
 
 def anchor_to_wire(a: Anchor) -> dict:
@@ -290,7 +304,7 @@ def hand_shape_to_wire(h: HandShape) -> dict:
 
 
 def chord_template_to_wire(ct: ChordTemplate) -> dict:
-    return {
+    out = {
         "name": ct.name,
         # ChordTemplate.display_name defaults to "" on the dataclass, but
         # the spec defaults displayName to name. Fall back here so
@@ -302,6 +316,10 @@ def chord_template_to_wire(ct: ChordTemplate) -> dict:
         "fingers": list(ct.fingers),
         "frets": list(ct.frets),
     }
+    # Harmony voicing (§6.6) — default-omitted, only when non-empty.
+    if ct.voicing:
+        out["voicing"] = ct.voicing
+    return out
 
 
 def _wire_int_optional(v, default=-1):
@@ -479,6 +497,30 @@ def note_from_wire(d: dict, time: float | None = None) -> Note:
     )
 
 
+def _validate_fn(raw) -> dict | None:
+    """Validate an optional chord harmony function (§6.3.1).
+
+    Returns a clean ``{"rn", "q", "deg"}`` dict only when ``raw`` is an object
+    with a non-empty ``rn`` string, a non-empty ``q`` string, and an int ``deg``
+    in 0..11. Any malformed / missing-key / out-of-range input -> ``None`` so a
+    partial fn (which would fail the schema's required-keys rule) never rides the
+    wire. Display/teaching only — MUST NEVER feed a grader. Mirrors the
+    drop-to-default tolerance of `_sanitize_bend_curve`."""
+    if not isinstance(raw, dict):
+        return None
+    rn = raw.get("rn")
+    q = raw.get("q")
+    deg = raw.get("deg")
+    if not isinstance(rn, str) or not rn.strip():
+        return None
+    if not isinstance(q, str) or not q.strip():
+        return None
+    # bool is an int subclass — reject it so `deg=True` can't pass as 1.
+    if not isinstance(deg, int) or isinstance(deg, bool) or not (0 <= deg <= 11):
+        return None
+    return {"rn": rn.strip(), "q": q.strip(), "deg": deg}
+
+
 def chord_from_wire(d: dict) -> Chord:
     t = float(d.get("t", 0.0))
     return Chord(
@@ -486,6 +528,7 @@ def chord_from_wire(d: dict) -> Chord:
         chord_id=int(d.get("id", 0)),
         high_density=bool(d.get("hd", False)),
         notes=[note_from_wire(cn, time=t) for cn in d.get("notes", [])],
+        fn=_validate_fn(d.get("fn")),
     )
 
 
@@ -838,7 +881,9 @@ def arrangement_from_wire(d: dict) -> Arrangement:
                           display_name=ct.get("displayName", ct.get("name", "")),
                           arpeggio=bool(ct.get("arp", False)),
                           fingers=list(ct.get("fingers", [-1] * 6)),
-                          frets=list(ct.get("frets", [-1] * 6)))
+                          frets=list(ct.get("frets", [-1] * 6)),
+                          voicing=(ct.get("voicing")
+                                   if isinstance(ct.get("voicing"), str) else ""))
             for ct in d.get("templates", [])
         ],
         # `phrases` is optional — absent on single-level sources / older

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -10296,6 +10296,37 @@
                             lbl.scale.set(lblWS, lblHS, 1);
                         }
 
+                        // Harmony annotations (§6.3.1 / §6.6) — the chord's
+                        // function (fn.rn Roman numeral) and template voicing,
+                        // stacked above the chord name. Gated by the
+                        // teaching-marks opt-in (mirrors the 2D overlay). Display
+                        // only — never grading.
+                        if (_drawTeachingMarks && firstInShapeRun && !chordWireHighDensity(ch)) {
+                            const _h = chordHarmonyLabels(ch.fn, bundle.chordTemplates?.[ch.id]?.voicing);
+                            if (_h.rn || _h.voicing) {
+                                const hlW = 24 * K * _textSizeMul;
+                                const hlH = 9 * K * _textSizeMul;
+                                const frameLeft = cx - width / 2;
+                                const baseX = frameLeft - hlW / 2 + NW * 0.94;
+                                const opacity = Math.min(1, 0.3 + fade * 0.7) * chordTailMul;
+                                // Start one chord-name-height above the name and
+                                // stack upward so labels never overlap the gems.
+                                let hy = yMaxF + hlH * 1.6;
+                                const _drawHarmony = (text, colorHex) => {
+                                    if (!text) return;
+                                    const s = pChordLbl.get();
+                                    const m = txtMat(text, colorHex, true, 'chord');
+                                    if (s.material.map !== m.map) { s.material.map = m.map; s.material.needsUpdate = true; }
+                                    s.material.opacity = opacity;
+                                    s.position.set(baseX, hy, z);
+                                    s.scale.set(hlW, hlH, 1);
+                                    hy += hlH;
+                                };
+                                _drawHarmony(_h.rn, '#ffcc66');       // sd teaching color
+                                _drawHarmony(_h.voicing, '#7fd1ff');  // fg teaching color
+                            }
+                        }
+
                         // Shape-based barre detection for the 3D indicator.
                         // Drives off chord notes alone — independent of label
                         // availability, so charts whose chordTemplates lack a
@@ -11357,6 +11388,15 @@
             // unset/out of range.
             if (!Number.isInteger(sd) || sd < 0 || sd > 11) return '';
             return String(sd);
+        }
+        /** Harmony annotations (§6.3.1 / §6.6): display labels for a chord's
+         * function (instance `fn.rn` Roman numeral) and template `voicing`
+         * string. '' for each when absent/malformed. Pure; shared with the 2D
+         * highway and node-tested. Display only — never grading. */
+        function chordHarmonyLabels(fn, voicing) {
+            const rn = (fn && typeof fn.rn === 'string') ? fn.rn.trim() : '';
+            const vc = (typeof voicing === 'string') ? voicing.trim() : '';
+            return { rn, voicing: vc };
         }
 
         function bnvSampleAt(bnv, t) {

--- a/static/highway.js
+++ b/static/highway.js
@@ -509,6 +509,17 @@ function createHighway() {
         return String(sd);
     }
 
+    /** Harmony annotations (§6.3.1 / §6.6): display labels for a chord's
+     * harmonic function (the instance `fn.rn` Roman numeral) and its template
+     * `voicing` string. Returns '' for each when absent or malformed. Pure;
+     * node-tested and shared by both highways. Display/teaching only — MUST
+     * NEVER feed a grader (honesty rule). */
+    function chordHarmonyLabels(fn, voicing) {
+        const rn = (fn && typeof fn.rn === 'string') ? fn.rn.trim() : '';
+        const vc = (typeof voicing === 'string') ? voicing.trim() : '';
+        return { rn, voicing: vc };
+    }
+
     /** Teaching mark (§6.2.2): bucket drawn notes by their strum-group key `ch`.
      * Returns the groups (in first-seen order) for each ch value >= 0 that has
      * at least two members — a lone note is not a strum gesture. Pure; drives
@@ -2198,6 +2209,39 @@ function createHighway() {
                 ctx.textAlign = 'center';
                 ctx.textBaseline = 'bottom';
                 fillTextReadable(tmpl.name, labelX, labelY);
+            }
+
+            // Harmony annotations (§6.3.1 / §6.6) — the chord's function
+            // (fn.rn Roman numeral) and template voicing, stacked above the
+            // chord name. Gated behind the teaching-marks opt-in (same overlay
+            // class as sd/ch) so they don't clutter the default highway.
+            // Display only — never grading.
+            if (_showTeachingMarks && !ch.hd && p.scale > 0.15 && sorted.length > 0) {
+                const { rn, voicing } = chordHarmonyLabels(ch.fn, tmpl && tmpl.voicing);
+                if (rn || voicing) {
+                    const hx = hasNonZero
+                        ? (xMin + xMax) / 2
+                        : (sorted.length >= 2
+                            ? (fretX(frameLeftFret, p.scale, W) + fretX(frameRightFret, p.scale, W)) / 2
+                            : fretX(sorted[0].f, p.scale, W));
+                    // Baseline = just above where the chord name sits.
+                    const nameY = hasNonZero
+                        ? (p.y * H - actualTotalH / 2 - sz * 0.7 - sz * 0.4)
+                        : (p.y * H - sz * 0.8);
+                    ctx.font = `bold ${Math.max(10, sz * 0.32) | 0}px sans-serif`;
+                    ctx.textAlign = 'center';
+                    ctx.textBaseline = 'bottom';
+                    let stackY = nameY - sz * 0.5;
+                    if (rn) {
+                        ctx.fillStyle = '#ffcc66';   // matches the sd teaching color
+                        fillTextReadable(rn, hx, stackY);
+                        stackY -= sz * 0.45;
+                    }
+                    if (voicing) {
+                        ctx.fillStyle = '#7fd1ff';   // matches the fg teaching color
+                        fillTextReadable(voicing, hx, stackY);
+                    }
+                }
             }
 
             // Notes — wide colored bar for open strings inside a chord,

--- a/tests/js/highway_chord_harmony.test.js
+++ b/tests/js/highway_chord_harmony.test.js
@@ -1,0 +1,49 @@
+// Behavioural tests for the chord harmony-annotation render helper
+// chordHarmonyLabels (§6.3.1 / §6.6), shared by the 2D and 3D highways.
+// Pure, so we extract the function source by brace-matching and eval it in
+// isolation — same pattern as highway_teaching_marks.test.js.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function extractFn(src, name) {
+    const start = src.indexOf('function ' + name);
+    assert.ok(start >= 0, `function ${name} must exist`);
+    const open = src.indexOf('{', start);
+    let depth = 0;
+    for (let i = open; i < src.length; i++) {
+        if (src[i] === '{') depth++;
+        else if (src[i] === '}' && --depth === 0) return src.slice(start, i + 1);
+    }
+    throw new Error(`unbalanced braces extracting ${name}`);
+}
+
+function loadFn(file, name) {
+    const src = fs.readFileSync(path.join(__dirname, '..', '..', file), 'utf8');
+    return new Function('"use strict";' + extractFn(src, name) + `\nreturn ${name};`)();
+}
+
+const labels2D = loadFn('static/highway.js', 'chordHarmonyLabels');
+const labels3D = loadFn('plugins/highway_3d/screen.js', 'chordHarmonyLabels');
+
+for (const [name, fn] of [['2D', labels2D], ['3D', labels3D]]) {
+    test(`chordHarmonyLabels (${name}) surfaces rn + voicing`, () => {
+        assert.deepEqual(fn({ rn: 'ii7', q: 'm7', deg: 2 }, 'open'),
+            { rn: 'ii7', voicing: 'open' });
+    });
+
+    test(`chordHarmonyLabels (${name}) trims whitespace`, () => {
+        assert.deepEqual(fn({ rn: '  V7 ' }, '  drop2 '),
+            { rn: 'V7', voicing: 'drop2' });
+    });
+
+    test(`chordHarmonyLabels (${name}) empties absent / malformed inputs`, () => {
+        assert.deepEqual(fn(null, undefined), { rn: '', voicing: '' });
+        assert.deepEqual(fn({}, ''), { rn: '', voicing: '' });
+        assert.deepEqual(fn({ rn: 7 }, 7), { rn: '', voicing: '' });   // non-string
+        assert.deepEqual(fn(undefined, 'shell'), { rn: '', voicing: 'shell' });
+        assert.deepEqual(fn({ rn: 'vi' }, null), { rn: 'vi', voicing: '' });
+    });
+}

--- a/tests/test_song.py
+++ b/tests/test_song.py
@@ -17,6 +17,7 @@ from song import (
     arrangement_string_count,
     arrangement_to_wire,
     chord_from_wire,
+    chord_template_to_wire,
     chord_to_wire,
     sanitize_tempos,
     compute_smart_names,
@@ -393,6 +394,95 @@ def test_chord_notes_inherit_chord_time_on_deserialization():
     )
     result = chord_from_wire(chord_to_wire(c))
     assert all(n.time == 3.0 for n in result.notes)
+
+
+# ── Harmony annotations: chord fn (§6.3.1) + template voicing (§6.6) ──────────
+
+def test_chord_fn_round_trip():
+    """A well-formed fn {rn, q, deg} survives the wire under its literal key."""
+    c = Chord(
+        time=2.0, chord_id=0,
+        notes=[Note(time=2.0, string=0, fret=2)],
+        fn={"rn": "ii7", "q": "m7", "deg": 2},
+    )
+    wire = chord_to_wire(c)
+    assert wire["fn"] == {"rn": "ii7", "q": "m7", "deg": 2}
+    assert chord_from_wire(wire) == c
+
+
+def test_chord_fn_omitted_when_none():
+    """fn defaults to None and produces no `fn` key on the wire."""
+    wire = chord_to_wire(Chord(time=0.0, chord_id=0,
+                               notes=[Note(time=0.0, string=0, fret=0)]))
+    assert "fn" not in wire
+    assert chord_from_wire(wire).fn is None
+
+
+@pytest.mark.parametrize("bad", [
+    None,                                   # absent / null
+    "ii7",                                  # not an object
+    {},                                     # empty
+    {"rn": "ii7", "q": "m7"},               # missing deg
+    {"rn": "ii7", "deg": 2},                # missing q
+    {"q": "m7", "deg": 2},                  # missing rn
+    {"rn": "", "q": "m7", "deg": 2},        # blank rn
+    {"rn": "ii7", "q": "  ", "deg": 2},     # blank q
+    {"rn": "ii7", "q": "m7", "deg": 15},    # deg out of range (high)
+    {"rn": "ii7", "q": "m7", "deg": -1},    # deg out of range (low)
+    {"rn": "ii7", "q": "m7", "deg": "2"},   # deg not an int
+    {"rn": "ii7", "q": "m7", "deg": True},  # deg is a bool, not a real int
+    {"rn": 7, "q": "m7", "deg": 2},         # rn not a str
+])
+def test_chord_fn_malformed_drops_to_none(bad):
+    """Any malformed / partial / out-of-range fn decodes to None (never partial)."""
+    c = chord_from_wire({"t": 1.0, "id": 0, "notes": [], "fn": bad})
+    assert c.fn is None
+
+
+@pytest.mark.parametrize("bad_fn", [
+    {"rn": "ii7"},                          # missing q + deg
+    {"rn": "ii7", "q": "m7", "deg": 15},    # deg out of range
+    {"rn": "", "q": "m7", "deg": 2},        # blank rn
+])
+def test_chord_to_wire_drops_invalid_fn_on_emit(bad_fn):
+    """A directly-constructed Chord with a partial/out-of-range fn never rides the wire."""
+    wire = chord_to_wire(Chord(time=1.0, chord_id=0, notes=[], fn=bad_fn))
+    assert "fn" not in wire
+
+
+def test_chord_fn_strips_whitespace_on_decode():
+    c = chord_from_wire({"t": 1.0, "id": 0, "notes": [],
+                         "fn": {"rn": " V7 ", "q": " 7 ", "deg": 7}})
+    assert c.fn == {"rn": "V7", "q": "7", "deg": 7}
+
+
+def test_template_voicing_round_trip():
+    """A non-empty voicing survives the template wire + arrangement round-trip."""
+    ct = ChordTemplate(name="Am", display_name="Am", fingers=[-1, 0, 2, 2, 1, 0],
+                       frets=[-1, 0, 2, 2, 1, 0], voicing="open")
+    assert chord_template_to_wire(ct)["voicing"] == "open"
+    arr = Arrangement(name="Rhythm", chord_templates=[ct])
+    assert arrangement_from_wire(arrangement_to_wire(arr)).chord_templates[0] == ct
+
+
+def test_template_voicing_omitted_when_default():
+    """An empty voicing (the default) produces no `voicing` key."""
+    ct = ChordTemplate(name="Am", fingers=[-1] * 6, frets=[-1] * 6)
+    assert "voicing" not in chord_template_to_wire(ct)
+    arr = arrangement_from_wire(arrangement_to_wire(
+        Arrangement(name="Rhythm", chord_templates=[ct])))
+    assert arr.chord_templates[0].voicing == ""
+
+
+@pytest.mark.parametrize("bad", [None, 7, ["open"], {"v": "open"}])
+def test_template_voicing_tolerates_malformed(bad):
+    """A non-string voicing on the wire falls back to the empty default."""
+    arr = arrangement_from_wire({
+        "name": "Rhythm",
+        "templates": [{"name": "Am", "fingers": [-1] * 6, "frets": [-1] * 6,
+                       "voicing": bad}],
+    })
+    assert arr.chord_templates[0].voicing == ""
 
 
 # ── Arrangement round-trip ───────────────────────────────────────────────────


### PR DESCRIPTION
Part of got-feedback/feedback#334

PR 2 of 3 (stacked on #540). Renders the per-chord harmony annotations PR1 put on the wire. Editor authoring (PR3) follows.

> **Stacked:** based on `feat/chord-harmony-wire` (#540), not `main`. Review/merge #540 first; this diff shows only the render changes.

## What

Draws two chord-level harmony labels, mirroring the teaching-marks render (#538):

- **`fn.rn`** — the chord instance's harmonic-function Roman numeral (e.g. `ii7`, `V7`).
- **`voicing`** — the template's key-independent voicing string (e.g. `open`, `drop2`).

Both are stacked above the chord name on the **2D** (`static/highway.js`) and **3D** (`plugins/highway_3d/screen.js`) highways. A shared pure helper `chordHarmonyLabels(fn, voicing)` formats them (`''` when absent/malformed) and is node-tested against both files via the extract-and-eval pattern.

## Gating

Both labels are gated behind the **existing teaching-marks opt-in** (`_showTeachingMarks` / `teachingMarksVisible` bundle flag) — they're chord-level teaching overlays, same class as `sd`/`ch`, so they don't clutter the default highway.

## Honesty rule

Render only. No scoring / NoteVerifier path is touched.

## Tested locally

- `node tests/js/highway_chord_harmony.test.js` → **6 passed** (rn+voicing surfaced, whitespace trimmed, absent/non-string → `''`, both 2D and 3D helpers agree).
- `node tests/js/highway_teaching_marks.test.js` still passes.
- `node --check static/highway.js` and `node --check plugins/highway_3d/screen.js` clean.
- Independent Codex review (read-only, diff-only): caught one P2 (empty-note chord could deref `sorted[0].f` in the 2D fallback) — fixed by gating on `sorted.length > 0`; re-review clean.

CI may be red on infra; the above was verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)