### PR TITLE
fix(player): stop song name/timer overlapping the section map bar

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -25,6 +25,17 @@ html { scroll-behavior: smooth; }
 }
 #highway { flex: 1; width: 100%; min-height: 0; }
 
+/* The section_map plugin injects #section-map as #player's first child, a
+   ~20px bar pinned to top:0. #player-hud is also top:0/absolute but at a
+   higher z-index, so its song name (top-left) and timer (top-right) would
+   paint on top of that bar. When the bar is present, push the HUD's content
+   below it, preserving the HUD's original py-3 (0.75rem) inset *under* the
+   bar (bar height + py-3). The general-sibling combinator only matches when
+   #section-map precedes #player-hud — which is exactly how the plugin inserts
+   it (#highway sits between them) — so the bar-less layout is untouched.
+   ID-on-ID specificity overrides Tailwind's .py-3 top padding. */
+#section-map ~ #player-hud { padding-top: calc(20px + 0.75rem); }
+
 /* Player controls need their own stacking context so visualization
    plugins that paint absolutely-positioned overlays (e.g. the bundled
    3D Highway's WebGL wrap at z-index:2, or any community viz plugin)


### PR DESCRIPTION
Closes #566

## Problem
In the player main interface, the **song name** (top-left) and **timer** (top-right) paint on top of the `section_map` plugin's bar.

`#player-hud` is `position:absolute; top:0; z-index:10` with only `py-3` (12px) top padding. The `section_map` plugin injects `#section-map` as `#player`'s first child — a ~20px bar at `top:0; z-index:5`. The HUD has the higher z-index but starts only 12px down, so its text overlaps the bar on both sides.

## Fix
One raw-CSS rule in `static/style.css`:

```css
#section-map ~ #player-hud { padding-top: calc(20px + 0.75rem); }
```

- The general-sibling combinator (`~`) matches **only when** `#section-map` precedes `#player-hud` — exactly how the plugin inserts it (`#highway` sits between them) — so the **bar-less layout is untouched**.
- Two-ID specificity overrides Tailwind's `.py-3` top padding; `padding-bottom` stays at 12px.
- `calc(20px + 0.75rem)` = bar height + the HUD's original `py-3` inset, so the original spacing is preserved *below* the bar.
- Shared by both v2 (`index.html`) and v3 (reuses `#player-hud` + the `#section-map` hook).

Raw CSS in `style.css` — not Tailwind utilities — so no `tailwind.min.css` rebuild is needed.

## Review
Reviewed with Codex (gpt-5.4): confirmed the selector/specificity reasoning and the need for `~`; its one P2 (the original `26px` left only 6px below the bar) was addressed by switching to `calc(20px + 0.75rem)` to preserve the HUD's original inset.

## Testing
⚠️ The `section_map` plugin isn't checked out locally (external/community plugin), so the live overlap couldn't be rendered end-to-end. The offset is based on the plugin's known `height:20px`. Recommend a hands-on check with the section map active to confirm clearance before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)