### PR TITLE
fix(v3): make equipped theme recolor the sidebar background

### DIFF
--- a/static/v3/theme-core.js
+++ b/static/v3/theme-core.js
@@ -58,6 +58,18 @@
         // The app shell paints body via bg-fb-sidebar (covered above); cover a
         // bare body too so the radial-gradient fallback areas follow the theme.
         rules += 'html[data-fb-theme] body { background-color: rgb(var(--fbv-sidebar)); color: rgb(var(--fbv-text)); }\n';
+        // The sidebar's navy radial wash is hardcoded in v3.css (#v3-sidebar)
+        // and carries NO fb-* utility class, so the per-utility loop above
+        // can't reach it — it stayed navy under every theme, the most visible
+        // "backgrounds don't change" gap. Re-point it at the theme, mirroring
+        // v3.css's stops (#1e293b == default card, #0f172a == default bg).
+        // Only background-image is overridden, so background-attachment:fixed
+        // from v3.css is preserved. Gated by [data-fb-theme] => default look
+        // untouched. (Scroll-thumb colors are deliberately left alone: theming
+        // the resting thumb would out-specify v3.css's :hover lighten rule and
+        // kill it, and there's no palette token between border and textDim to
+        // reproduce the hover shade without color-mix, unused here.)
+        rules += 'html[data-fb-theme] #v3-sidebar { background-image: radial-gradient(circle at top, rgb(var(--fbv-card)) 0%, rgb(var(--fbv-bg)) 100%); }\n';
         return 'html[data-fb-theme] {\n' + vars + '}\n' + rules;
     }
 


### PR DESCRIPTION
Closes #569

## Problem
Equipping an interface theme recolored text, `fb-*` utility surfaces, and `body`, but the left **sidebar** stayed navy — so the UI read as "only fonts change, not backgrounds".

## Root cause
`theme-core.js` re-points `fb-*` utilities + `body` at `--fbv-*` vars under `html[data-fb-theme]`. These correctly outspecify Tailwind's static utilities (`html[data-fb-theme] .bg-fb-card` (0,2,1) > `.bg-fb-card` (0,1,0)), so cards/body/text **do** recolor. But `#v3-sidebar` is painted with a hardcoded radial gradient in `v3.css` and carries no `fb-*` class, so the override loop never reaches it:

```css
#v3-sidebar { background-image: radial-gradient(circle at top, #1e293b 0%, #0f172a 100%); }
/* #1e293b == default card, #0f172a == default bg */
```

Since the bundled themes are all dark (brown/green/purple), the content shift is subtle while the unchanged always-visible sidebar + obvious accent/text changes made it read as "only fonts change".

## Fix
Extend `cssFor()` (which already special-cases `body`) to re-point the sidebar gradient at the theme, gated by `html[data-fb-theme]`:

```js
rules += 'html[data-fb-theme] #v3-sidebar { background-image: radial-gradient(circle at top, rgb(var(--fbv-card)) 0%, rgb(var(--fbv-bg)) 100%); }\n';
```

- `html[data-fb-theme] #v3-sidebar` (1,1,1) outspecifies `v3.css` `#v3-sidebar` (1,0,0), and the injected `<style>` is after the `v3.css` `<link>` — overrides reliably.
- Only `background-image` is overridden, so `background-attachment: fixed` from v3.css is preserved.
- Vars exist only under `[data-fb-theme]`, so the **default (no-theme) look is untouched**.
- Gradient mirrors v3.css's `card → bg` stops.

No Tailwind rebuild (rules are runtime-generated, per constitution P-II).

## Scope notes (from review)
- **Scroll thumbs deliberately not themed.** An earlier draft also themed the scrollbar thumbs, but the resting-thumb override (1,1,2) out-specifies v3.css's `::-webkit-scrollbar-thumb:hover` rule (1,0,2) and would kill the hover-lighten; there's no palette token between `border` and `textDim` to reproduce the hover shade without `color-mix` (unused in the codebase). Dropped to keep the fix regression-free and on-target.
- **In-song player chrome** (`#player` `#050508`, rail popovers) is a separate, deliberately near-black surface family — out of scope; can be themed separately if desired.

## Review & verification
Thorough self-review (Codex CLI was rate-limited, resets Jun 25; CodeRabbit will auto-review):
- Confirmed the specificity/cascade claims against the compiled `static/tailwind.min.css` and all competing `#v3-sidebar` / scrollbar rules in `v3.css`.
- Confirmed all 3 bundled themes (`shop.json`) include every palette key, so no undefined-var fallbacks are hit.
- **Verified in headless Chromium** against the real `tailwind.min.css` + `v3.css` + `theme-core.js`:
  - Default (no theme): sidebar = navy gradient `rgb(30,41,59) → rgb(15,23,42)`, `data-fb-theme` absent.
  - `apply(moss-amp)`: sidebar recolors to `rgb(27,46,35) → rgb(15,26,20)` (card → bg); body + card also recolor.
  - `apply(null)` (unequip): sidebar reverts to navy, `data-fb-theme` removed.
  - All 7 assertions PASS.

## Manual check suggested
Equip e.g. *Moss Amp* / *Violet Fuzz* / *Sunset Strat* in a real build and confirm the sidebar tracks the theme and the no-theme default is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)