### PR TITLE
fix(onboarding): calibration Tuner step exposed the input-select overlay underneath

### DIFF
--- a/plugins/input_setup/screen.js
+++ b/plugins/input_setup/screen.js
@@ -163,10 +163,25 @@
 
                 host.querySelector('[data-is-cal]').addEventListener('click', () => {
                     if (hasDetector) {
+                        // Hide our own full-screen overlay while note_detect's
+                        // Calibration Wizard runs on top. That wizard goes
+                        // transparent (pointer-events:none) when it minimizes to
+                        // expose the Tuner; if our overlay stayed up it would show
+                        // through — covering the tuner with the still-mounted
+                        // "select your input" card and looking like a second
+                        // wizard at the input step. Restore it on done/cancel
+                        // (one of which always fires when that wizard closes).
+                        const ov = document.getElementById('input-setup-overlay');
+                        const prevDisplay = ov ? ov.style.display : '';
+                        if (ov) ov.style.display = 'none';
+                        const restore = () => {
+                            const o = document.getElementById('input-setup-overlay');
+                            if (o) o.style.display = prevDisplay;
+                        };
                         window.noteDetect.launchCalibration({
                             instrument: inst,
-                            onDone: () => advance(inst, true),
-                            onCancel: () => { /* stay on this panel; user can skip or retry */ },
+                            onDone: () => { restore(); advance(inst, true); },
+                            onCancel: () => { restore(); /* stay on this panel; user can skip or retry */ },
                         });
                     } else {
                         advance(inst, true);

--- a/static/v3/profile.js
+++ b/static/v3/profile.js
@@ -222,23 +222,39 @@
         if (!instruments.length) return;
         // Don't let a plugin-load race skip the mandatory input-setup step.
         if (!(await waitForInputSetup(8000))) return;
-        const caps = window.feedBack && window.feedBack.capabilities;
-        if (!caps || typeof caps.command !== 'function') {
-            try { await window.feedBackInputSetup.launch(instruments); } catch (e) { /* proceed */ }
-            return;
+        // Hide this onboarding modal while the input-setup wizard (its own
+        // full-screen overlay) runs on top. Otherwise both stay stacked, and when
+        // the note-detect calibration wizard minimizes to expose the Tuner the
+        // onboarding modal shows through behind the tuner. Restored in `finally`
+        // before we advance to the calibration-challenge step.
+        const ob = document.getElementById('v3-onboarding');
+        const obPrevDisplay = ob ? ob.style.display : '';
+        if (ob) ob.style.display = 'none';
+        const restoreOnboarding = () => {
+            const o = document.getElementById('v3-onboarding');
+            if (o) o.style.display = obPrevDisplay;
+        };
+        try {
+            const caps = window.feedBack && window.feedBack.capabilities;
+            if (!caps || typeof caps.command !== 'function') {
+                try { await window.feedBackInputSetup.launch(instruments); } catch (e) { /* proceed */ }
+                return;
+            }
+            await new Promise((resolve) => {
+                let settled = false;
+                let unsub = null;
+                const done = () => { if (settled) return; settled = true; try { unsub && unsub(); } catch (e) { /* noop */ } resolve(); };
+                try { unsub = typeof caps.subscribe === 'function' ? caps.subscribe('input-calibration:calibration-done', done) : null; } catch (e) { unsub = null; }
+                // `run` is fire-and-launch; completion arrives via the event above.
+                // A non-handled outcome (no owner / plugin absent / error) means
+                // nothing was launched, so proceed immediately.
+                caps.command('input-calibration', 'run', { requester: 'onboarding', payload: { instruments } })
+                    .then((r) => { if (!r || r.outcome !== 'handled') done(); })
+                    .catch(() => done());
+            });
+        } finally {
+            restoreOnboarding();
         }
-        await new Promise((resolve) => {
-            let settled = false;
-            let unsub = null;
-            const done = () => { if (settled) return; settled = true; try { unsub && unsub(); } catch (e) { /* noop */ } resolve(); };
-            try { unsub = typeof caps.subscribe === 'function' ? caps.subscribe('input-calibration:calibration-done', done) : null; } catch (e) { unsub = null; }
-            // `run` is fire-and-launch; completion arrives via the event above.
-            // A non-handled outcome (no owner / plugin absent / error) means
-            // nothing was launched, so proceed immediately.
-            caps.command('input-calibration', 'run', { requester: 'onboarding', payload: { instruments } })
-                .then((r) => { if (!r || r.outcome !== 'handled') done(); })
-                .catch(() => done());
-        });
     }
 
     function show(profile, opts) {


### PR DESCRIPTION
## Bug
Tester report: *"I get to the point in the wizard that asks if I want to tune. If I press the tuner button, the wizard starts a second instance at the step where I need to select an input."*

## Root cause
Stacked full-screen overlays during onboarding:

| Layer | Overlay | z-index |
|---|---|---|
| onboarding modal | `#v3-onboarding` | 200 |
| input-device setup | `#input-setup-overlay` | 210 |
| note_detect Calibration Wizard | (inline) | 300 |
| Tuner | `#tuner-plugin-ui` | 1000 |

`input_setup` launches note_detect's Calibration Wizard *on top* of its own still-mounted overlay. When the player opens the Tuner, the calibration wizard minimizes itself to `background:transparent; pointer-events:none` so the Tuner (z-1000) is usable — but the input-setup overlay underneath (still on its "select your input" card) then shows through behind the floating tuner, reading as a *second wizard at the input step*. The onboarding modal (z-200) sits behind that.

## Fix
Hide each overlay while a higher surface owns the screen:
- **input_setup** — hide `#input-setup-overlay` while `launchCalibration` runs; restore on its `onDone`/`onCancel` (note_detect's `calibrationWizardClose` always fires exactly one of them, so it can't get stuck hidden).
- **onboarding `runInputSetup`** — hide `#v3-onboarding` for the whole input-setup phase (the input-setup overlay replaces it visually anyway); restore in a `finally` before advancing to the calibration-challenge step.

Net: device-selection shows only the input-setup overlay; the calibration wizard shows alone; the Tuner shows alone over a clear screen.

**Holding for Codex review (usage-limited until ~Jun 25) before merge.** Related: note_detect PR #38 (the calibration-wizard tester-feedback batch) — its auto-open-tuner change would have made this overlay collision fire automatically, so this is the necessary companion fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)