### PR TITLE
fix(minigames): rescue pre-rename minigame plugins (dead FeedBarcade tiles)

### DIFF
--- a/plugins/minigames/plugin.json
+++ b/plugins/minigames/plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "minigames",
   "name": "Minigames",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "bundled": true,
   "private": false,
   "screen": "screen.html",

--- a/plugins/minigames/screen.js
+++ b/plugins/minigames/screen.js
@@ -961,7 +961,25 @@
   // Drain queue of plugins that loaded before us.
   (window.__feedBackMinigamesPending || []).forEach(register);
   window.__feedBackMinigamesPending = null;
+
+  // ── Back-compat for pre-rename minigame plugins ───────────────────────
+  // Minigame plugins published before the slopsmith→feedBack rename (#537)
+  // register against `window.slopsmithMinigames` and, when the SDK isn't up
+  // yet, queue to `window.__slopsmithMinigamesPending`. The rename moved the
+  // SDK to `window.feedBackMinigames` and only drains the feedBack queue, so
+  // those plugins' specs — including community ones we don't control — get
+  // stranded in the legacy queue and never register. Their FeedBarcade tiles
+  // then render as dead "Loading…" placeholders that do nothing on click.
+  // Alias the SDK under the old name and drain the legacy pending queue too.
+  // register() is keyed on spec.id, so a plugin that queued under both names
+  // still registers exactly once.
+  window.slopsmithMinigames = sdk;
+  (window.__slopsmithMinigamesPending || []).forEach(register);
+  window.__slopsmithMinigamesPending = null;
+
   window.dispatchEvent(new CustomEvent('feedBack-minigames-ready'));
+  // Legacy event name for any pre-rename listener still bound to it.
+  window.dispatchEvent(new CustomEvent('slopsmith-minigames-ready'));
 
   // ── Wire hub render to screen lifecycle ───────────────────────────────
   // FeedBack mounts plugin screens with id "plugin-<plugin_id>" and


### PR DESCRIPTION
## Problem
In the v3 UI, some FeedBarcade tiles are **visible but not clickable** — clicking does nothing, no pointer cursor. Diagnosed live in a desktop AppImage.

Root cause is a **half-finished slopsmith→feedBack rename (#537)** in the minigames registration handshake:

- The bundled minigames SDK now publishes `window.feedBackMinigames` and drains only `window.__feedBackMinigamesPending`.
- Minigame plugins that still use the pre-rename shim register against `window.slopsmithMinigames` and, when the SDK isn't up yet, queue to `window.__slopsmithMinigamesPending`.
- Nothing drains that legacy queue, so those specs **never register**. `feedbarcade.js` gates a tile's launchability on the JS spec being registered (`registeredList()`); the tile itself comes from the *server* registry (`/api/plugins/minigames/registry`), so it still renders — as a dead `Loading… reload if this persists` placeholder with no click handler.

Confirmed on a live build — `window` carried both `__feedBackMinigamesPending` **and** an undrained `__slopsmithMinigamesPending`.

## Fix
After draining the feedBack queue, also:
- alias `window.slopsmithMinigames = sdk`,
- drain `window.__slopsmithMinigamesPending`,
- fire the legacy `slopsmith-minigames-ready` event.

`register()` is keyed on `spec.id`, so a plugin that queues under both names still registers exactly once. Plugin version bumped `0.1.0 → 0.1.1` so the desktop renderer cache-busts `screen.js` (the loader keys the `?v=` on plugin version).

This rescues **every** not-yet-migrated minigame plugin generically, including community plugins. The paired plugin-side fix (forward-compat shim) is in got-feedback/feedback-plugin-strum-fighter.

## Verification
- `node --check` on `screen.js`; `plugin.json` parses.
- Mechanism proven live: draining `__slopsmithMinigamesPending` into the SDK by hand made the stuck tile clickable.

> Note: got-feedback org Actions are billing-blocked, so CI checks here are expected to fail "job was not started" — not a code signal. Verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)