### PR TITLE
fix(player): new song no longer seeks to previous song's stop position

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -5958,6 +5958,10 @@ async function playSong(filename, arrangement, options) {
     clearLoop();
     _resetSectionPracticeLog();
     _hideSectionPracticeBar();
+    // Reset so the jump-fix (setInterval, ~line 8979) doesn't mistake the new
+    // song starting at t=0 for an unexpected seek from the previous song's
+    // position. audio.currentTime may not reset synchronously when src is cleared.
+    lastAudioTime = 0;
 
     currentFilename = filename;
     // A fresh load arms autoplay; a pending auto-exit from the previous


### PR DESCRIPTION
## Summary

- `audio.currentTime` does not reset synchronously when `audio.src = ''` — it only resets when `audio.load()` is called (later, in `highway.js`)
- The jump-fix guard (`setInterval` ~line 8979) retained `lastAudioTime` at the old position; once the new song started playing from t=0, `Math.abs(0 - oldPos) > 30` fired and sought the new song to the previous position
- If the new song was shorter than the old stop time, `song:ended` fired immediately → score screen

**Fix:** reset `lastAudioTime = 0` in `playSong()` so the guard has no stale anchor to trigger against.

## Reproduces as

1. Play any song, stop it mid-way (e.g. at 2:00)
2. Go to library, pick a different (shorter) song
3. New song immediately jumps to 2:00 and ends → score screen

## Test plan

- [ ] Play Song A to ~2:00, navigate to library, play Song B — confirm B starts at 0:00
- [ ] Play Song A to ~2:00, navigate to library, play a song shorter than 2:00 — confirm it plays normally from start, not score screen
- [ ] Normal A-B loop and seek still work (jump-fix still guards against genuine 30s+ jumps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)