### PR TITLE
feat(v3): promote Audio Engine to a first-class sidebar entry (after Settings)

### DIFF
--- a/static/v3/shell.js
+++ b/static/v3/shell.js
@@ -50,6 +50,7 @@
         { key: 'virtuoso',    screen: 'plugin-virtuoso',    label: 'Virtuoso - Practice', group: null, icon: 'target' },
         { key: 'rig_builder', screen: 'plugin-rig_builder', label: 'Rig Builder', group: null,      icon: 'amp' },
         { key: 'editor',      screen: 'plugin-editor',      label: 'Song Editor', group: null,      icon: 'edit' },
+        { key: 'audio_engine', screen: 'plugin-audio_engine', label: 'Audio', group: null,        icon: 'amp' },
         // Not in the sidebar groups, but routable (profile badge → here).
         { key: 'profile',   screen: 'v3-profile',   label: 'Profile',         group: null,      icon: 'user' },
     ];
@@ -61,6 +62,7 @@
         { navKey: 'virtuoso',    pluginId: 'virtuoso',    slotId: 'v3-nav-virtuoso',    anchorAfter: 'feedbarcade' },
         { navKey: 'rig_builder', pluginId: 'rig_builder', slotId: 'v3-nav-rig-builder', anchorAfter: 'saved' },
         { navKey: 'editor',      pluginId: 'editor',      slotId: 'v3-nav-editor',     anchorAfter: 'songs' },
+        { navKey: 'audio_engine', pluginId: 'audio_engine', slotId: 'v3-nav-audio-engine', anchorAfter: 'settings' },
     ];
     const TOPBAR_KEYS = ['home', 'songs', 'plugins', 'settings'];
     const SIDEBAR_GROUPS = ['HOME', 'LIBRARY'];


### PR DESCRIPTION
## Why
The Audio Engine plugin is a core **desktop** surface — input-device selection, VST hosting, amp modeling, pitch detection, and now the config **Reset / repair** UI (feedback-desktop #38). But in the v3 shell it was reachable only through the generic **Plugins** gallery: per-plugin manifest `nav` entries aren't surfaced in the sidebar unless the plugin is in `PROMOTED_PLUGINS`. That made it — and the config-reset section inside its settings — hard to find.

## What
`static/v3/shell.js`:
- Add a `NAV` registry entry for `audio_engine` (`group: null`, screen `plugin-audio_engine`, label **"Audio"**, 🎸 `amp` icon) so the promoted slot resolves its label/screen.
- Add a `PROMOTED_PLUGINS` entry anchored `anchorAfter: 'settings'` → renders an **"Audio"** item right after **Settings** in the sidebar.

Desktop-only by construction: `renderPromotedNav()` fills the slot only when `/api/plugins` reports `audio_engine` installed, so the web app shows nothing there (no dead entry that bounces to Plugins).

## Tests
- `node --check static/v3/shell.js` — clean.
- `capability_inspector_nav.test.js` → 6/6, `plugins_page.test.js` → 11/11 (the suites covering nav/promoted plugins).
- Full sidebar render needs the desktop build (the plugin only exists in the desktop bundle), so verify the "Audio" entry there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)