### PR TITLE
fix(v3): Playlists New/Rename/bulk-add no-op in desktop (prompt → uiPrompt)

### DIFF
--- a/static/v3/playlists.js
+++ b/static/v3/playlists.js
@@ -104,7 +104,7 @@
                 : '<p class="text-fb-textDim">No playlists yet. Create one to group songs.</p>') +
             '</div>';
         root.querySelector('#v3-pl-new')?.addEventListener('click', async () => {
-            const name = (window.prompt('Playlist name?') || '').trim();
+            const name = ((await window.uiPrompt({ title: 'New Playlist', label: 'Playlist name', okLabel: 'Create', placeholder: 'My Playlist' })) || '').trim();
             if (!name) return;
             await jsend('POST', '/api/playlists', { name });
             renderPlaylists();
@@ -137,7 +137,7 @@
         const listEl = root.querySelector('#v3-pl-songs');
         if (listEl) wireSongRows(listEl, pid, () => renderPlaylistDetail(pid));
         root.querySelector('#v3-pl-rename')?.addEventListener('click', async () => {
-            const name = (window.prompt('Rename playlist', pl.name) || '').trim();
+            const name = ((await window.uiPrompt({ title: 'Rename Playlist', label: 'Playlist name', value: pl.name, okLabel: 'Rename' })) || '').trim();
             if (!name) return;
             await jsend('PATCH', '/api/playlists/' + pid, { name });
             renderPlaylistDetail(pid);

--- a/static/v3/songs.js
+++ b/static/v3/songs.js
@@ -595,8 +595,13 @@
     async function batchAddToPlaylist() {
         const lists = (await jget('/api/playlists')) || [];
         const choices = lists.filter((p) => !p.system_key);
-        const labels = choices.map((p, i) => (i + 1) + '. ' + p.name).join('\n');
-        const ans = (window.prompt('Add ' + state.selected.size + ' song(s) to which playlist?\n' + labels + '\n\nEnter a number, or a new playlist name:', '') || '').trim();
+        const labels = choices.map((p, i) => (i + 1) + '. ' + p.name).join('   ');
+        const ans = ((await window.uiPrompt({
+            title: 'Add ' + state.selected.size + ' song(s) to a playlist',
+            label: (labels ? labels + ' ' : '') + 'Type a number above, or a new playlist name:',
+            okLabel: 'Add',
+            placeholder: 'Number or new playlist name',
+        })) || '').trim();
         if (!ans) return;
         let pid = null;
         const num = parseInt(ans, 10);


### PR DESCRIPTION
## Problem
`window.prompt()` is a **silent no-op in the Electron desktop shell**, so several Playlists actions did nothing when clicked on the desktop app:
- **Playlists → New Playlist**
- **Playlists → Rename** (playlist detail)
- **Songs → bulk "add selected to a playlist"**

## Fix
Route all three through the existing in-app **`window.uiPrompt()`** modal (resolves to the entered string, or `null` on cancel). The handlers were already `async`, so it drops in directly.

- `static/v3/playlists.js` — New + Rename
- `static/v3/songs.js` — `batchAddToPlaylist`

`window.confirm()` (the Delete confirmation) works in Electron and is intentionally left as-is — only `prompt()` is the broken primitive.

## Tests
- `node --check` clean on both files.
- `v3_songs_scroll` 7/7, `v3_songs_tuning` 5/5.
- Confirmed no `window.prompt()` remains anywhere in `static/v3`.

## Follow-up
The bulk add-to-playlist (`songs.js`) is now functional but uses a single-line modal asking for "a number or a new name" — it deserves a proper playlist-picker (list + ＋New). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)