### PR TITLE
fix: "practise" -> "practice" (match the rest of the UI)

### DIFF
--- a/plugins/achievements/engine.py
+++ b/plugins/achievements/engine.py
@@ -109,7 +109,7 @@ def apply_activity(counters, delta):
 def consecutive_run_length(dates):
     """Longest run of consecutive calendar dates in ``dates`` (ISO 'YYYY-MM-DD').
 
-    Used by the `secret_witching` Feat (practise in the 2–5am window on N
+    Used by the `secret_witching` Feat (practice in the 2–5am window on N
     consecutive nights). Pure date arithmetic so it's unit-testable; routes.py
     feeds it the distinct night-dates recorded in `comp_ledger`.
     """

--- a/plugins/achievements/feats.json
+++ b/plugins/achievements/feats.json
@@ -76,7 +76,7 @@
     {
       "id": "secret_witching",
       "title": "The Witching Hour",
-      "description": "Practise in the dead of night, seven nights running.",
+      "description": "Practice in the dead of night, seven nights running.",
       "category": "global",
       "sourceId": "achievements",
       "secret": true,

--- a/static/v3/profile.js
+++ b/static/v3/profile.js
@@ -375,7 +375,7 @@
             // Step 3 — Achievements wall opt-in (first-run only; default OFF).
             '<div id="v3-ob-step3" class="hidden">' +
             '<label class="block text-xs uppercase tracking-wider text-fb-textDim mb-2">Feats of Power</label>' +
-            '<p class="text-sm text-fb-textDim mb-3">As you practise you’ll earn rare <span class="text-fb-text">Feats of Power</span> — silly, bombastic activity trophies. Want to show them off on the public <span class="text-fb-text">Feats wall</span>?</p>' +
+            '<p class="text-sm text-fb-textDim mb-3">As you practice you’ll earn rare <span class="text-fb-text">Feats of Power</span> — silly, bombastic activity trophies. Want to show them off on the public <span class="text-fb-text">Feats wall</span>?</p>' +
             '<label class="flex items-start gap-3 cursor-pointer rounded-lg border border-fb-border/50 bg-fb-bg/40 p-3">' +
             '<input type="checkbox" id="v3-ob-optin" class="mt-1 h-4 w-4 rounded border-gray-600 bg-gray-800 text-fb-primary focus:ring-fb-primary">' +
             '<span class="text-sm text-fb-text">Share my Feats on the wall' +


### PR DESCRIPTION
Spotted in the first-run onboarding dialog. Three spots used British **"practise"** while the rest of the app uses American **"practice"** ("Keep practicing", "Virtuoso - Practice", practice-aware home, …).

- `static/v3/profile.js` — onboarding step 3 ("As you **practise** you'll earn rare Feats of Power")
- `plugins/achievements/feats.json` — *The Witching Hour* feat description
- `plugins/achievements/engine.py` — code comment

Text-only; `feats.json` validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)