### PR TITLE
Add progress bar to v3 "Up Next" pill

### DIFF
--- a/static/v3/index.html
+++ b/static/v3/index.html
@@ -855,9 +855,12 @@
                     <div id="v3-live-performance-state" class="v3-live-performance-state" aria-hidden="true"></div>
                 </div>
                 <div id="v3-upnext" class="v3-upnext hidden">
-                    <span class="text-gray-400">Up Next:</span>
-                    <span id="v3-upnext-name" class="v3-upnext-name"></span>
-                    <span id="v3-upnext-eta" class="text-gray-400 text-xs"></span>
+                    <div class="v3-upnext-row">
+                        <span class="text-gray-400">Up Next:</span>
+                        <span id="v3-upnext-name" class="v3-upnext-name"></span>
+                        <span id="v3-upnext-eta" class="text-gray-400 text-xs"></span>
+                    </div>
+                    <div class="v3-upnext-bar"><div id="v3-upnext-bar-fill" class="v3-upnext-bar-fill"></div></div>
                 </div>
             </div>
         </div>

--- a/static/v3/player-chrome.js
+++ b/static/v3/player-chrome.js
@@ -187,6 +187,19 @@
         const nm = $('v3-upnext-name'), eta = $('v3-upnext-eta');
         if (nm) nm.textContent = next.name || '—';
         if (eta) eta.textContent = 'in ' + dt.toFixed(1) + 's';
+        // Progress bar: fraction of the current section elapsed toward `next`.
+        // Previous boundary is the last section at/before now (else song start).
+        const fill = $('v3-upnext-bar-fill');
+        if (fill) {
+            let prevT = 0;
+            for (let i = 0; i < secs.length; i++) {
+                if (typeof secs[i].time === 'number' && secs[i].time <= t) prevT = secs[i].time;
+                else break;
+            }
+            const span = next.time - prevT;
+            const prog = span > 0 ? Math.max(0, Math.min(1, (t - prevT) / span)) : 0;
+            fill.style.width = (prog * 100).toFixed(1) + '%';
+        }
         pill.classList.remove('hidden');
     }
 

--- a/static/v3/v3.css
+++ b/static/v3/v3.css
@@ -340,8 +340,9 @@ input, textarea, select,
 /* — Up Next pill (top-right, persistent) — */
 #player-hud .v3-upnext {
     display: flex;
-    align-items: center;
-    gap: .5rem;
+    flex-direction: column;
+    align-items: stretch;
+    gap: .35rem;
     padding: .45rem .9rem;
     border-radius: .75rem;
     background: rgba(15, 23, 42, .7);
@@ -351,6 +352,26 @@ input, textarea, select,
     pointer-events: auto;
 }
 #player-hud .v3-upnext.hidden { display: none; }
+/* Text row keeps the original inline layout untouched. */
+#player-hud .v3-upnext .v3-upnext-row {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+}
+/* Progress bar under the text — fills as the current section elapses. */
+#player-hud .v3-upnext .v3-upnext-bar {
+    height: 4px;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, .25);
+    overflow: hidden;
+}
+#player-hud .v3-upnext .v3-upnext-bar-fill {
+    height: 100%;
+    width: 0%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, #22d3ee, #a855f7, #f472b6);
+    transition: width .12s linear;
+}
 
 /* — Live performance HUD (top-right, read-only) — */
 .v3-live-performance-hud {


### PR DESCRIPTION
## What

The persistent top-right **Up Next** pill (v3 player chrome) showed the upcoming section name and a countdown (`in 12.3s`) but gave no at-a-glance sense of how far through the *current* section the song is. This adds a thin progress bar directly under the existing text that fills as the current section elapses toward the next, reaching full when the section flips.

## How

- **`static/v3/index.html`** — wrap the three existing spans in a `.v3-upnext-row` (inline layout unchanged) and add a `.v3-upnext-bar` track + fill below it.
- **`static/v3/v3.css`** — the pill now stacks (column); 4px rounded track with a gradient fill that matches the section-name gradient.
- **`static/v3/player-chrome.js`** — `updateUpNext()` computes progress as the fraction elapsed between the previous section boundary (last section at/before now, else song start) and the next section, and sets the fill width. Runs on the same ~6 Hz pill tick; a short CSS width transition smooths it.

Nothing else about the pill's content or text styling changes. Gated by the existing "Show 'Up Next'" pref like the rest of the pill.

## Test plan

- Play a song with section markers; watch the top-right pill: a bar under "Up Next:" fills smoothly and hits full as each section flips.
- Before the first section, the bar tracks from song start toward the first section.
- On the final section (no upcoming) the pill hides as before.
- Verified over the 3D Highway viz (where it was reported); the pill is core chrome and renders over any viz.

<img width="436" height="136" alt="up-next" src="https://github.com/user-attachments/assets/0b09a47e-00fc-46cc-8927-c904be2b9a64" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)