### PR TITLE
Port the Min res (minimum auto-resolution) selector into the v3 player

### DIFF
--- a/static/v3/index.html
+++ b/static/v3/index.html
@@ -927,6 +927,15 @@
                     </select>
                 </div>
                 <div class="v3-pop-row">
+                    <span class="v3-pop-label" id="min-scale-label">Min res</span>
+                    <select id="min-scale-select" onchange="highway.setMinRenderScale && highway.setMinRenderScale(parseFloat(this.value))" class="v3-pop-select" aria-labelledby="min-scale-label" title="Minimum auto resolution — how far the highway may lower its resolution to hold the frame rate on heavy scenes. 'Full' disables auto-downscaling, but the Quality selector still caps the maximum (so it's only full resolution at Quality = HD).">
+                        <option value="0.25">25%</option>
+                        <option value="0.5">50%</option>
+                        <option value="0.75">75%</option>
+                        <option value="1">Full</option>
+                    </select>
+                </div>
+                <div class="v3-pop-row">
                     <span class="v3-pop-label" id="scoreboard-label">Scoreboard</span>
                     <select id="scoreboard-select" onchange="setScoreboard(this.value)" class="v3-pop-select" aria-labelledby="scoreboard-label" title="Highway scoreboard">
                         <option value="core" selected>Streak</option>


### PR DESCRIPTION
Fixes #662.

## What
Add the **Min res** selector to the v3 viz/quality rail popover (`static/v3/index.html`), directly under Quality — porting the existing v2 control (`static/index.html`).

## Why
The v2 player exposes a Min res selector that caps how far the load-adaptive resolution scaler (feedBack#654) may downscale (or disables it via **Full**). v3 only ported Quality, leaving v3 users no way to stop the highway dropping to quarter-res on heavy scenes / weak-GPU launches — pixelated even at Quality = HD. This is the user-facing escape hatch companion to the Windows hybrid-GPU root-cause fix (got-feedback/feedback-desktop#53).

## Notes
- No JS needed: `setMinRenderScale`/`getMinRenderScale` live in `static/highway.js`, and the shared `static/app.js` init (guarded by `getElementById`) already syncs the selector's value on load — it was a no-op in v3 before, now it finds the new element.
- Markup mirrors the proven v2 control (same options 0.25/0.5/0.75/Full, handler, title, `aria-labelledby`).

## Verification
- Codex review: **CLEAN** (well-formed markup, no v3 id collision, init wiring confirmed, API + option range match, aria correct).
- ⚠️ Not yet runtime-rendered in a live v3 instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)