### PR TITLE
fix(tuner): transactional open + fail-closed auto-open config (tuner-E #655 review)

### DIFF
--- a/plugins/tuner/routes.py
+++ b/plugins/tuner/routes.py
@@ -56,7 +56,11 @@ def setup(app: FastAPI, context: dict):
             res["visualizationMode"] = str(data.get("visualizationMode", "default"))
             raw_mode = str(data.get("audioInputMode", "auto"))
             res["audioInputMode"] = raw_mode if raw_mode in ("auto", "browser") else "auto"
-            res["autoOpenOnTuningChange"] = bool(data.get("autoOpenOnTuningChange", False))
+            # Fail closed: only a real JSON boolean enables the opt-in. A hand-edited /
+            # migrated / bad-client value (e.g. the string "false" or "0") must NOT be
+            # coerced to True by bool().
+            _auto_open = data.get("autoOpenOnTuningChange", False)
+            res["autoOpenOnTuningChange"] = _auto_open if isinstance(_auto_open, bool) else False
 
             if not isinstance(res["customTunings"], dict):
                 res["customTunings"] = {}

--- a/plugins/tuner/screen.js
+++ b/plugins/tuner/screen.js
@@ -13,6 +13,10 @@
     let _lastAutoOpenSessionKey = null;
     let _autoOpenDismissedSessionKey = null;
     let _autoOpenGeneration = 0;
+    // Bumped on every enable()/disable() so an in-flight open (which awaits audio start
+    // with the panel already visible) can detect it was dismissed mid-open and NOT flip
+    // _state.enabled on afterwards — avoiding a zombie enabled-but-hidden tuner.
+    let _openGen = 0;
     let _onAutoOpenSongLoading = null;
     let _onAutoOpenSongReady = null;
 
@@ -540,6 +544,7 @@
 
     async function enable(opts) {
         if (_state.enabled) return;
+        const myOpen = ++_openGen;   // this open's token; a disable()/newer open invalidates it
         // An AUTO-open (the "this song needs a different tuning" nudge) must
         // PERSIST: it is NOT dismissed by the autoplay song:play that follows
         // song entry, a stray click, or a same-screen re-emit — only by the
@@ -612,6 +617,10 @@
                 { deviceId: _state.selectedDeviceId, channel: _state.selectedChannel, audioInputMode: _state.audioInputMode },
                 _tunerUIApi.updateUI
             );
+            // The panel is visible (with ×/Skip) across the audio-start await above, so a
+            // dismiss can land here. If so, disable() already tore the panel down and
+            // bumped _openGen — do NOT flip enabled on (that would leave enabled-but-hidden).
+            if (myOpen !== _openGen) return;
             _state.enabled = true;
             if (window.tuner?.updateButtons) window.tuner.updateButtons();
         } catch (e) {
@@ -622,6 +631,7 @@
     }
 
     function disable() {
+        _openGen++;   // invalidate any in-flight enable() so it won't re-enable after this teardown
         const wasEnabled = _state.enabled;
         const wasAutoOpened = _state.autoOpened;
         const onPlayer = document.getElementById('player')?.classList.contains('active');

--- a/tests/js/tuner_auto_open.test.js
+++ b/tests/js/tuner_auto_open.test.js
@@ -544,3 +544,36 @@ test('publish skips when the instrument could not be confidently resolved (setti
     sandbox.window._tunerAutoOpen.publishWorkingTuning(DROP_D);
     assert.equal(sets.length, 0);
 });
+
+// ── #655 fix: transactional open — a dismiss during the audio-start await must not
+// re-enable the tuner afterward (no zombie enabled-but-hidden state). See issue #675.
+test('dismiss during the audio-start await does not leave a zombie enabled tuner', async () => {
+    const sandbox = createTunerSandbox({ player: { instrument: 'guitar', string_count: 6, tuning: 'Standard' } });
+    // Minimal UI so real enable() gets past the panel-show line to the audio-start await
+    // (the default sandbox _tunerUI is a no-op that never creates uiContainer).
+    const el = () => ({
+        classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+        querySelector: () => null, appendChild() {}, remove() {}, style: {},
+    });
+    const origTunerUI = sandbox.window._tunerUI;   // the sandbox's full no-op method set
+    sandbox.window._tunerUI = (state, actions) => {
+        const api = origTunerUI(state, actions);
+        state.uiContainer = el();
+        state.vizContainer = el();
+        state.skipBtn = el();
+        api.showMicError = api.showMicError || (() => {});
+        return api;
+    };
+    // The OPEN's audio start resolves only AFTER a ×/Skip dismiss has landed — i.e. the
+    // user dismissed while audio was starting. (disable()'s own background-audio resume
+    // is a later call and resolves at once.)
+    let firstStart = true;
+    sandbox.window._tunerAudio.start = () => {
+        if (!firstStart) return Promise.resolve();
+        firstStart = false;
+        return Promise.resolve().then(() => { sandbox.window.tuner.disable(); });
+    };
+    await sandbox.window.tuner.enable({ auto: true });
+    assert.equal(sandbox.window._tunerAutoOpen.getState().enabled, false,
+        'a mid-open dismiss must win — the tuner stays disabled, not enabled-but-hidden');
+});

--- a/tests/plugins/tuner/test_config.py
+++ b/tests/plugins/tuner/test_config.py
@@ -95,6 +95,20 @@ class TestConfigPersistence:
         client.post("/api/plugins/tuner/config", json={"audioInputMode": "browser"})
         assert client.get("/api/plugins/tuner/config").json()["audioInputMode"] == "browser"
 
+    def test_auto_open_defaults_false(self, client):
+        assert client.get("/api/plugins/tuner/config").json()["autoOpenOnTuningChange"] is False
+
+    def test_auto_open_true_accepted(self, client):
+        client.post("/api/plugins/tuner/config", json={"autoOpenOnTuningChange": True})
+        assert client.get("/api/plugins/tuner/config").json()["autoOpenOnTuningChange"] is True
+
+    def test_auto_open_fail_closed_on_non_bool(self, client):
+        # A hand-edited / bad-client non-boolean (e.g. the string "false") must NOT be
+        # coerced to True by bool() — the opt-in stays off.
+        for bad in ("false", "0", "1", "yes", 1, {}):
+            client.post("/api/plugins/tuner/config", json={"autoOpenOnTuningChange": bad})
+            assert client.get("/api/plugins/tuner/config").json()["autoOpenOnTuningChange"] is False, bad
+
     def test_disabled_tunings_strips_entries_without_colon(self, client):
         client.post("/api/plugins/tuner/config", json={
             "disabledTunings": ["guitar-6:Drop D", "legacy-entry", "bass-4:Standard"]


### PR DESCRIPTION
Review fixes for the **#655** stage (auto-open opt-in + persist) of the tuner-E stack. Targets `feat/v3-tuner-coverage-badge` (where the stack + #660 already live).

Closes #675 — **enable() wasn't transactional.** The panel (with ×/Skip) is shown before `await _tunerAudio.start()`, and `_state.enabled` was only set *after* it. A dismiss during that await hit `disable()` with `wasEnabled=false`, then enable() completed and flipped `enabled` on → an enabled-but-hidden zombie. Now guarded with an `_openGen` token (bumped on every enable()/disable()); after the audio-start await, enable() bails if superseded.

Closes #676 — **config wasn't fail-closed.** `routes.py` used `bool(data.get("autoOpenOnTuningChange", False))`, coercing "false"/"0"/junk to `True`. Now accepts only a real JSON boolean.

**Tests:** `tuner_auto_open.test.js` (dismiss-mid-open stays disabled — verified it fails without the token guard) + `test_config.py` (default-false + fail-closed on non-bool). 34 JS + 24 config tests green.

Part of the tuner-E review-fix set (stages #655/#656/#657); see also the #656 and #657 fix PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)