### PR TITLE
fix(tuner): coverage stays conservative when the instrument is unknown (tuner-E #656 review)

### DIFF
--- a/plugins/tuner/screen.js
+++ b/plugins/tuner/screen.js
@@ -225,9 +225,13 @@
             if (named && Array.isArray(named[s.tuning])) freqs = named[s.tuning];
         }
         if (!freqs) {
-            // No settings AND no live tuning → we can't tell the player's tuning; fail
-            // toward prompting (null → coverage treats it as not-covered).
-            if (!s && !wtHasOffsets) return null;
+            // No confident instrument identity — settings absent, OR present but carrying
+            // no instrument/string_count/tuning (a fresh profile: /api/settings omits them)
+            // — and no live working tuning. We can't tell the player's tuning, so fail
+            // toward prompting (null → not-covered) rather than silently assuming standard
+            // and suppressing a genuinely-needed prompt.
+            const hasIdentity = !!(s && (s.instrument || s.string_count || s.tuning));
+            if (!hasIdentity && !wtHasOffsets) return null;
             freqs = u.offsetsToFreqs(new Array(sc).fill(0), isBass);   // standard fallback
         }
         const midis = _openMidisFromFreqs(freqs);

--- a/tests/js/tuner_auto_open.test.js
+++ b/tests/js/tuner_auto_open.test.js
@@ -577,3 +577,17 @@ test('dismiss during the audio-start await does not leave a zombie enabled tuner
     assert.equal(sandbox.window._tunerAutoOpen.getState().enabled, false,
         'a mid-open dismiss must win — the tuner stays disabled, not enabled-but-hidden');
 });
+// ── #656 fix: coverage stays conservative when the instrument identity is unknown.
+// A fresh profile (/api/settings omits instrument/string_count/tuning) must NOT be
+// assumed to be standard guitar and silently suppress the prompt. See issue #677.
+test('coverage is conservative when settings carry no instrument identity', async () => {
+    const sandbox = createTunerSandbox({ player: {} });   // settings object, but no instrument fields
+    const covered = await sandbox.window._tunerAutoOpen.coveredByPlayerInstrument(E_STANDARD);
+    assert.equal(covered, false, 'unknown instrument → not covered → still prompt');
+});
+
+test('a configured standard-guitar player still covers a standard song', async () => {
+    const sandbox = createTunerSandbox({ player: { instrument: 'guitar', string_count: 6, tuning: 'Standard' } });
+    const covered = await sandbox.window._tunerAutoOpen.coveredByPlayerInstrument(E_STANDARD);
+    assert.equal(covered, true, 'a known standard guitar covers a standard song (no regression)');
+});


### PR DESCRIPTION
Review fix for the **#656** stage (instrument-coverage check) of the tuner-E stack. Targets `feat/v3-tuner-coverage-badge`.

Closes #677 — `_playerTuning()` is documented conservative ('missing data → not covered → still prompt'), but when `/api/settings` carries no instrument identity (a fresh profile: `_default_settings()` omits `instrument`/`string_count`/`tuning`) it invented `guitar`/`6`/`440`/standard, so an unconfigured player was treated as 6-string E-standard and coverage suppressed the prompt for matching songs. The post-#660 rewrite only returned null on a full fetch failure (`!s`), not when settings existed but lacked an instrument.

Now returns `null` unless there's a confident identity — any of `instrument`/`string_count`/`tuning` in settings, or live working-tuning offsets. A configured standard guitar still covers a standard song (no regression).

**Tests:** empty-settings → not covered (verified it fails without the fix); configured standard guitar → still covered.

Part of the tuner-E review-fix set (#655/#656/#657).

🤖 Generated with [Claude Code](https://claude.com/claude-code)