### PR TITLE
fix(tuner): badge cue staleness + unknown-as-warning + dedupe (tuner-E #657 review)

### DIFF
--- a/plugins/tuner/screen.js
+++ b/plugins/tuner/screen.js
@@ -289,7 +289,7 @@
     // — cantCover: the song needs more strings than the instrument has.
     // Conservative: any missing data → { covered:false } so a needed prompt/cue is
     // never silently dropped on a fetch hiccup.
-    async function _coverageReport(songInfo) {
+    async function _computeCoverageReport(songInfo) {
         const u = window._tunerUtils;
         const none = { covered: false, retune: [], reference: false, cantCover: false };
         if (!u) return none;
@@ -315,6 +315,23 @@
         return { covered, retune: covered ? [] : best, reference, cantCover: false };
     }
 
+    // Dedup the coverage computation (which fetches /api/settings): the auto-open gate
+    // AND the badge cue both call this on the same song:ready. Cache the in-flight/last
+    // result per song so they share ONE fetch. Invalidated when anything that changes the
+    // answer happens — a new song (song:loading), an instrument switch (instrument:changed),
+    // or a retune (working-tuning-changed) — so the cache can never go stale within a song.
+    let _coverageCache = null;   // { key, promise }
+    function _coverageReport(songInfo) {
+        const key = _autoOpenSessionKey(songInfo) + '|'
+            + (songInfo && Array.isArray(songInfo.tuning) ? songInfo.tuning.join(',') : '')
+            + '|' + (songInfo && songInfo.centOffset != null ? songInfo.centOffset : '');   // coverage uses centOffset
+        if (_coverageCache && _coverageCache.key === key) return _coverageCache.promise;
+        const promise = _computeCoverageReport(songInfo);
+        _coverageCache = { key, promise };
+        return promise;
+    }
+    function _invalidateCoverageCache() { _coverageCache = null; }
+
     // Boolean form used to gate the auto-open prompt.
     async function _coveredByPlayerInstrument(songInfo) {
         return (await _coverageReport(songInfo)).covered;
@@ -324,6 +341,7 @@
         _autoOpenGeneration++;
         _autoOpenDismissedSessionKey = null;
         _lastAutoOpenSessionKey = null;
+        _invalidateCoverageCache();
     }
 
     async function _maybeAutoOpenOnTuningChange() {
@@ -390,7 +408,10 @@
         // switches instrument. Drop the cached selection so a publish-on-clear can't write
         // to the previously-selected instrument's slot; the next coverage read re-resolves
         // it. Until then _publishWorkingTuning skips (safe — no mis-slotted write).
-        window.feedBack.on('instrument:changed', () => { _state._playerSelected = null; });
+        window.feedBack.on('instrument:changed', () => { _state._playerSelected = null; _invalidateCoverageCache(); });
+        // A retune (working tuning published on a tuner clear) changes coverage for the
+        // current song — drop the cached report so a re-evaluation recomputes it.
+        window.feedBack.on('working-tuning-changed', _invalidateCoverageCache);
     }
 
     // ── Player sync helpers ───────────────────────────────────────────

--- a/static/v3/badges.js
+++ b/static/v3/badges.js
@@ -29,6 +29,9 @@
     // drives a passive "different tuning" cue on the tuner badge. null = covered /
     // unknown / off the player.
     let _lastCoverageReport = null;
+    // Monotonic token so a slow coverage fetch can't restore a stale cue after a newer
+    // song started loading / we left the player. Bumped on every refresh and clear.
+    let _coverageCueToken = 0;
     function _tuningsForKey(key) { return Object.keys(_tuningsByKey[key] || {}); }
     function _tuningsForInstrument(instrument, string_count) {
         return _tuningsForKey(instrument + '-' + string_count);
@@ -282,14 +285,30 @@
         btn.title = 'This song needs a different tuning — retune ' + summary + '. Click to tune.';
     }
 
+    // A coverage report only drives the cue when it carries an actual signal: covered
+    // (clears the ring) or a nameable mismatch (retune / reference / cantCover). The
+    // plugin returns a conservative all-false report on a fetch hiccup / missing data —
+    // that's "unknown", NOT "needs retune", so collapse it to null (no cue) rather than
+    // painting an amber "retune the reference pitch" ring with no evidence.
+    function _meaningfulReport(report) {
+        if (!report) return null;
+        if (report.covered) return report;
+        if (report.cantCover || report.reference || (report.retune && report.retune.length)) return report;
+        return null;
+    }
+
     async function _refreshCoverageCue() {
+        const myToken = ++_coverageCueToken;
         const songInfo = window.highway && window.highway.getSongInfo && window.highway.getSongInfo();
         const api = window._tunerAutoOpen;
         if (!songInfo || !api || typeof api.coverageReport !== 'function') {
             _lastCoverageReport = null; _applyCoverageCue(null); return;
         }
-        try { _lastCoverageReport = await api.coverageReport(songInfo); }
-        catch (_e) { _lastCoverageReport = null; }
+        let report = null;
+        try { report = await api.coverageReport(songInfo); }
+        catch (_e) { report = null; }
+        if (myToken !== _coverageCueToken) return;   // superseded by a newer song / a clear
+        _lastCoverageReport = _meaningfulReport(report);
         _applyCoverageCue(_lastCoverageReport);
     }
 
@@ -411,9 +430,9 @@
             // Passive coverage cue: recompute when a song is ready; clear when a new
             // song starts loading or we leave the player screen.
             sm.on('song:ready', () => { _refreshCoverageCue(); });
-            sm.on('song:loading', () => { _lastCoverageReport = null; _applyCoverageCue(null); });
+            sm.on('song:loading', () => { _coverageCueToken++; _lastCoverageReport = null; _applyCoverageCue(null); });
             sm.on('screen:changed', (e) => {
-                if (!e || !e.detail || e.detail.id !== 'player') { _lastCoverageReport = null; _applyCoverageCue(null); }
+                if (!e || !e.detail || e.detail.id !== 'player') { _coverageCueToken++; _lastCoverageReport = null; _applyCoverageCue(null); }
             });
         }
     }

--- a/tests/js/tuner_auto_open.test.js
+++ b/tests/js/tuner_auto_open.test.js
@@ -591,3 +591,22 @@ test('a configured standard-guitar player still covers a standard song', async (
     const covered = await sandbox.window._tunerAutoOpen.coveredByPlayerInstrument(E_STANDARD);
     assert.equal(covered, true, 'a known standard guitar covers a standard song (no regression)');
 });
+// ── #657 fix (#680): coverage is deduped — the auto-open gate and the badge cue both
+// call coverageReport() on the same song:ready; they must share ONE /api/settings fetch.
+test('coverage reports for the same song share one settings fetch, and a new song refetches', async () => {
+    const sandbox = createTunerSandbox({ player: { instrument: 'guitar', string_count: 6, tuning: 'Standard' } });
+    let settingsFetches = 0;
+    const origFetch = sandbox.window.fetch;
+    sandbox.window.fetch = (url) => {
+        if (String(url).includes('/api/settings')) settingsFetches += 1;
+        return origFetch(url);
+    };
+    const api = sandbox.window._tunerAutoOpen;
+    const [a, b] = await Promise.all([api.coverageReport(DROP_D), api.coverageReport(DROP_D)]);
+    assert.equal(settingsFetches, 1, 'concurrent reports for the same song share one fetch');
+    assert.deepEqual(a, b);
+    // A new song invalidates the cache → a fresh fetch.
+    api.onSongLoading();
+    await api.coverageReport(E_STANDARD);
+    assert.equal(settingsFetches, 2, 'a new song refetches');
+});


### PR DESCRIPTION
Review fixes for the **#657** stage (passive 'different tuning' badge cue) of the tuner-E stack. Targets `feat/v3-tuner-coverage-badge`.

Closes #678 — **stale async cue.** `_refreshCoverageCue` awaited `coverageReport` then wrote the DOM unconditionally, so a slow `/api/settings` fetch could restore the previous song's amber ring after `song:loading` / leaving the player. Added a monotonic token (bumped on every refresh + both clear paths); the awaited report applies only if the token still matches.

Closes #679 — **"unknown" rendered as "needs retune".** The plugin returns a conservative all-false report on a fetch hiccup; the cue painted it as an amber "retune the reference pitch" ring. `_meaningfulReport()` collapses a no-signal report to `null` (no cue). A genuine not-covered report always carries `reference`/`retune`/`cantCover` (`covered = !reference && best.length===0`), so real cues are preserved.

Closes #680 — **duplicate `/api/settings` fetch.** The auto-open gate and the badge cue both call `coverageReport()` per `song:ready`. Now caches the coverage *promise* per song (keyed by session + tuning + centOffset) so they share one fetch; invalidated on `song:loading`, `instrument:changed`, and `working-tuning-changed` so it can't go stale within a song.

**Tests:** concurrent reports share one fetch + a new song refetches (fails without the cache). 34 JS tests green. Codex-reviewed (confirmed #678/#679 correct, #680 correct; added `centOffset` to the cache key per its note).

Part of the tuner-E review-fix set (#655/#656/#657).

🤖 Generated with [Claude Code](https://claude.com/claude-code)