### PR TITLE
v3 library: native right-click context menu on cards

### DIFF
--- a/static/v3/songs.js
+++ b/static/v3/songs.js
@@ -1355,7 +1355,7 @@
                 }
                 if (window.v3Playlists) { try { window.v3Playlists.refresh(); } catch (e) { /* */ } }
                 if (acts.length && window.fbNotify) {
-                    try { window.fbNotify.show({ title: 'Playlists updated', message: 'Updated ' + acts.length + ' playlist' + (acts.length === 1 ? '' : 's'), icon: '\U0001f3b5' }); } catch (e) { /* */ }
+                    try { window.fbNotify.show({ title: 'Playlists updated', message: 'Updated ' + acts.length + ' playlist' + (acts.length === 1 ? '' : 's'), icon: '🎵' }); } catch (e) { /* */ }
                 }
                 done(acts.length ? true : null);
             }
@@ -2549,6 +2549,9 @@
     async function render() {
         const root = document.getElementById('v3-songs');
         if (!root) return;
+        // A full re-render (filter/scan refresh) replaces the DOM the card menu
+        // anchored to; dismiss any open menu first so it can't float orphaned.
+        if (_closeCardMenu) _closeCardMenu();
         // Restore last-used sort/format/view/filters once, before building the
         // toolbar so its selects reflect the saved choice (default: Artist A–Z).
         if (!_prefsRestored) { applySavedPrefs(); _prefsRestored = true; }

--- a/static/v3/songs.js
+++ b/static/v3/songs.js
@@ -831,7 +831,7 @@
     // Per-card action menu, built from the ui.library-card-injection registry
     // (core Edit/Retune + any plugin-registered actions).
     let _closeCardMenu = null;   // tears down the currently-open card menu + its document closer
-    function openCardMenu(cardEl, song, anchorBtn) {
+    function openCardMenu(cardEl, song, anchorBtn, pos) {
         // Fully close any already-open menu first — removing just the DOM node
         // (as before) would orphan its document-level click closer.
         if (_closeCardMenu) _closeCardMenu();
@@ -841,7 +841,9 @@
         // Undefined placement defaults to the menu.
         const items = (reg ? reg.list(song) : []).filter((a) => !a.placement || a.placement === 'menu');
         const menu = document.createElement('div');
-        menu.className = 'v3-card-menu absolute top-10 right-2 z-30 min-w-[10rem] bg-fb-card border border-fb-border/60 rounded-lg shadow-xl py-1 text-sm';
+        // pos (right-click) positions the menu at the pointer via `fixed`;
+        // the ⋮ button keeps the absolute top-right anchor.
+        menu.className = 'v3-card-menu z-30 min-w-[10rem] bg-fb-card border border-fb-border/60 rounded-lg shadow-xl py-1 text-sm ' + (pos ? 'fixed' : 'absolute top-10 right-2');
         // Multi-chart entries (P5d): a grouped grid row carries chart_count +
         // work_key (P5a annotation), so the menu knows inline whether this card
         // stands for versions. Local library only — the work API is local.
@@ -860,6 +862,7 @@
             ...(state.provider === 'local' && song.is_split
                 ? [{ id: '__unsplit', label: 'Rejoin other versions' }] : []),
             { id: '__playlist', label: 'Add to playlist' },
+            { id: '__save', label: 'Save for later' },
             ...items.map((a) => ({ id: a.id, label: a.label, destructive: a.destructive, enabled: a.enabled, plugin: a.pluginId })),
         ];
         menu.innerHTML = rows.map((r) =>
@@ -867,7 +870,17 @@
             (r.enabled === false ? 'opacity-40 cursor-not-allowed ' : '') +
             (r.destructive ? 'text-fb-accent' : 'text-fb-text') + '">' + esc(r.label) +
             (r.plugin && r.plugin !== 'core' ? '<span class="text-[10px] text-fb-textDim ml-1">' + esc(r.plugin) + '</span>' : '') + '</button>').join('');
-        cardEl.appendChild(menu);
+        if (pos) {
+            // Right-click: position the menu at the pointer (fixed, viewport-
+            // relative), clamped so it never spills off the right/bottom edge.
+            document.body.appendChild(menu);
+            const x = Math.min(pos.x, window.innerWidth - menu.offsetWidth - 8);
+            const y = Math.min(pos.y, window.innerHeight - menu.offsetHeight - 8);
+            menu.style.left = Math.max(8, x) + 'px';
+            menu.style.top = Math.max(8, y) + 'px';
+        } else {
+            cardEl.appendChild(menu);
+        }
         // Tear down BOTH the menu and its document-level closer together, so a
         // menu-item click doesn't leave the closer attached (it would otherwise
         // leak, retaining this menu's closures until the next document click).
@@ -888,6 +901,7 @@
                 return;
             }
             if (id === '__playlist') { await addFilenamesToPlaylist([song.filename]); return; }
+            if (id === '__save') { if (window.v3Saved) await window.v3Saved.toggle(song.filename); return; }
             if (reg) await reg.run(id, song, { source: 'v3-songs' });
         }));
         // Tree rows ride the (ungrouped) artists endpoint, so they don't carry
@@ -1167,6 +1181,8 @@
                 playCard(playTarget);   // local → play; unsynced remote → sync then play
             }));
             el.querySelector('[data-menu]')?.addEventListener('click', (e) => { e.stopPropagation(); openCardMenu(el, song, e.currentTarget); });
+            // Native right-click opens the same overflow menu at the pointer.
+            el.addEventListener('contextmenu', (e) => { e.preventDefault(); openCardMenu(el, song, null, { x: e.clientX, y: e.clientY }); });
             el.querySelectorAll('[data-arr]').forEach((ab) => ab.addEventListener('click', (e) => {
                 e.stopPropagation();
                 const idx = ab.getAttribute('data-arr');


### PR DESCRIPTION
Adds a **native right-click** context menu to library song cards — right-clicking opens the *same* overflow (⋮) menu at the pointer, so Play / Add to playlist / Save for later / any plugin card actions are reachable without aiming for the small ⋮ button.

## Change
- `openCardMenu` gains an optional **pointer position**: opened via right-click it's `fixed` and clamped to the viewport (never spills off an edge); the ⋮ button keeps the existing card-anchored placement.
- Binds `contextmenu` (preventDefault) on every library card (grid + tree rows) via `wireCards`.
- Adds a **"Save for later"** row to the menu, closing the inconsistency where Save was only the inline 🔖 button.
- One menu definition + the existing `libraryCardActions` registry, so plugin-provided actions appear in both the ⋮ and right-click paths.

## Verification
`+17/-3` in `songs.js`, parses. (Right-click positioning/clamp is DOM behavior — worth an on-device glance.)

Stacked on #672 (picker) so right-click's "Add to playlist" opens the modern picker; base retargets to `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbexxfTt8q2tAn436MqGWF
