### PR TITLE
v3 library: genre filter facet (reads feedpak genres)

### DIFF
--- a/lib/sloppak.py
+++ b/lib/sloppak.py
@@ -919,6 +919,8 @@ def extract_meta(path: Path) -> dict:
         "artist": str(manifest.get("artist", "")),
         "album": str(manifest.get("album", "")),
         "year": str(manifest.get("year", "") or ""),
+        # Primary genre from the feedpak `genres` list (spec 1.12.0); [0] = primary.
+        "genre": (lambda g: str(g[0]) if isinstance(g, list) and g else "")(manifest.get("genres")),
         "duration": float(manifest.get("duration", 0) or 0),
         "tuning_offsets": tuning_offsets,  # caller maps to a name via tunings.tuning_name
         "arrangements": arrangements,

--- a/server.py
+++ b/server.py
@@ -7178,8 +7178,22 @@ async def library_stats(favorites: int = 0, q: str = "", format: str = "",
 
 
 @app.get("/api/library/genres")
-def library_genres():
-    """Distinct non-empty genres for the filter facet (local library)."""
+def library_genres(provider: str = "local"):
+    """Distinct non-empty genres for the filter facet.
+
+    Genres are a local-library facet: they're populated from the feedpak
+    `genres` field at scan time and live in the local meta DB. Local-backed
+    providers (the local library and its smart collections, kind="local")
+    share that DB, so they surface the same set. Remote providers don't
+    expose genres here, so return an empty facet for them — the client then
+    hides the filter rather than offering local genres that don't apply to
+    the remote grid. Mirrors the local/remote gating used elsewhere for
+    provider calls (see `_call_library_provider`)."""
+    library_provider = _get_library_provider(provider)
+    kind = str(library_providers.provider_field(library_provider, "kind", "") or "")
+    is_remote = kind not in ("", "local") if kind else provider != "local"
+    if is_remote:
+        return {"genres": []}
     with meta_db._lock:
         rows = meta_db.conn.execute(
             "SELECT DISTINCT genre FROM songs WHERE genre IS NOT NULL AND genre != '' "

--- a/server.py
+++ b/server.py
@@ -550,7 +550,8 @@ class MetadataDB:
                 stem_ids TEXT DEFAULT '[]',
                 tuning_name TEXT DEFAULT '',
                 tuning_sort_key INTEGER DEFAULT 0,
-                tuning_offsets TEXT DEFAULT ''
+                tuning_offsets TEXT DEFAULT '',
+                genre TEXT DEFAULT ''
             )
         """)
         # Idempotent migrations for installs that predate each column.
@@ -569,6 +570,9 @@ class MetadataDB:
             # distinct custom tunings distinct (tuning_name collapses them all
             # to "Custom Tuning"). Cache; repopulated on rescan.
             "ALTER TABLE songs ADD COLUMN tuning_offsets TEXT DEFAULT ''",
+            # Primary genre from the feedpak `genres` list (spec 1.12.0). Cache;
+            # repopulated on rescan.
+            "ALTER TABLE songs ADD COLUMN genre TEXT DEFAULT ''",
         ):
             try:
                 self.conn.execute(ddl)
@@ -584,6 +588,7 @@ class MetadataDB:
         self.conn.execute("CREATE INDEX IF NOT EXISTS idx_songs_title_fn ON songs(title COLLATE NOCASE, filename)")
         self.conn.execute("CREATE INDEX IF NOT EXISTS idx_songs_mtime_fn ON songs(mtime, filename)")
         self.conn.execute("CREATE INDEX IF NOT EXISTS idx_songs_tuning_name ON songs(tuning_name COLLATE NOCASE)")
+        self.conn.execute("CREATE INDEX IF NOT EXISTS idx_songs_genre ON songs(genre COLLATE NOCASE)")
         self.conn.execute("CREATE INDEX IF NOT EXISTS idx_songs_tuning_sort_key ON songs(tuning_sort_key)")
         self.conn.execute("CREATE INDEX IF NOT EXISTS idx_songs_year ON songs(year)")
         self.conn.execute("CREATE TABLE IF NOT EXISTS favorites (filename TEXT PRIMARY KEY)")
@@ -2548,8 +2553,8 @@ class MetadataDB:
             self.conn.execute(
                 "INSERT OR REPLACE INTO songs "
                 "(filename, mtime, size, title, artist, album, year, duration, tuning, arrangements, "
-                "has_lyrics, format, stem_count, stem_ids, tuning_name, tuning_sort_key, tuning_offsets) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "has_lyrics, format, stem_count, stem_ids, tuning_name, tuning_sort_key, tuning_offsets, genre) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (filename, mtime, size, meta.get("title", ""), meta.get("artist", ""),
                  meta.get("album", ""), meta.get("year", ""), meta.get("duration", 0),
                  meta.get("tuning", ""), json.dumps(meta.get("arrangements", [])),
@@ -2559,7 +2564,8 @@ class MetadataDB:
                  json.dumps(meta.get("stem_ids", []) or []),
                  meta.get("tuning_name", "") or "",
                  int(meta.get("tuning_sort_key", 0) or 0),
-                 meta.get("tuning_offsets", "") or ""),
+                 meta.get("tuning_offsets", "") or "",
+                 meta.get("genre", "") or ""),
             )
             self.conn.commit()
             # A song's identity may have changed → the grouping read-model is stale.
@@ -2926,6 +2932,7 @@ class MetadataDB:
                      tags_has: list[str] | None = None,
                      user_difficulty_in: list[str] | None = None,
                      match_states: list[str] | None = None,
+                     genre: list[str] | None = None,
                      naming_mode: str = "legacy",
                      include_intrinsic: bool = True) -> tuple[str, list]:
         """Shared WHERE-clause builder for query_page / query_artists /
@@ -2955,6 +2962,12 @@ class MetadataDB:
         if album_filter:
             where += " AND album = ? COLLATE NOCASE"
             params.append(album_filter)
+        # Genre facet (primary genre column, populated from the feedpak `genres`
+        # list on scan). OR within the selected set.
+        if genre:
+            _gph = ",".join(["?"] * len(genre))
+            where += f" AND genre COLLATE NOCASE IN ({_gph})"
+            params += list(genre)
         # Mastery bands = best accuracy across a song's arrangements (song_stats,
         # a separate table -> correlated subquery). mastered >= 0.9, in_progress =
         # attempted but < 0.9, not_started = no score. OR within the selected set.
@@ -3437,6 +3450,7 @@ class MetadataDB:
                    tags_has: list[str] | None = None,
                    user_difficulty_in: list[str] | None = None,
                    match_states: list[str] | None = None,
+                   genre: list[str] | None = None,
                    after: str | None = None,
                    group: bool = False,
                    naming_mode: str = "legacy") -> tuple[list[dict], int]:
@@ -3467,7 +3481,7 @@ class MetadataDB:
             stems_has=stems_has, stems_lacks=stems_lacks,
             has_lyrics=has_lyrics, tunings=tunings, mastery=mastery,
             tags_has=tags_has, user_difficulty_in=user_difficulty_in,
-            match_states=match_states,
+            match_states=match_states, genre=genre,
             naming_mode=naming_mode, include_intrinsic=not group,
         )
         ifrag, iparams = "", []
@@ -6989,7 +7003,7 @@ async def list_library(q: str = "", page: int = 0, size: int = 24, sort: str = "
                        stems_has: str = "", stems_lacks: str = "",
                        has_lyrics: str = "", tunings: str = "", provider: str = "local",
                        mastery: str = "", tags: str = "", user_difficulty: str = "",
-                       match: str = "", after: str = "", group: int = 0,
+                       match: str = "", genre: str = "", after: str = "", group: int = 0,
                        naming_mode: str = "legacy"):
     """Paginated library search through the selected library provider.
 
@@ -7019,6 +7033,7 @@ async def list_library(q: str = "", page: int = 0, size: int = 24, sort: str = "
         tags_has=_split_csv(tags),
         user_difficulty_in=_split_csv(user_difficulty),
         match_states=_split_csv(match),
+        genre=_split_csv(genre),
         **_library_filter_args(
             q=q, favorites=favorites, format=format,
             artist=artist, album=album,
@@ -7160,6 +7175,17 @@ async def library_stats(favorites: int = 0, q: str = "", format: str = "",
             has_lyrics=has_lyrics, tunings=tunings,
         ),
     )
+
+
+@app.get("/api/library/genres")
+def library_genres():
+    """Distinct non-empty genres for the filter facet (local library)."""
+    with meta_db._lock:
+        rows = meta_db.conn.execute(
+            "SELECT DISTINCT genre FROM songs WHERE genre IS NOT NULL AND genre != '' "
+            "ORDER BY genre COLLATE NOCASE"
+        ).fetchall()
+    return {"genres": [r[0] for r in rows]}
 
 
 @app.get("/api/library/tuning-names")

--- a/static/v3/songs.js
+++ b/static/v3/songs.js
@@ -2548,7 +2548,7 @@
             loadArtistCatalog(),
         ]);
         state.tuningNames = (tn && tn.tunings) || [];
-        try { const _g = await jget('/api/library/genres'); state.genres = (_g && _g.genres) || []; } catch (e) { state.genres = []; }
+        try { const _g = await jget('/api/library/genres?provider=' + enc(state.provider)); state.genres = (_g && _g.genres) || []; } catch (e) { state.genres = []; }
 
         const opt = (arr, sel) => arr.map(([v, l]) => '<option value="' + esc(v) + '"' + (v === sel ? ' selected' : '') + '>' + esc(l) + '</option>').join('');
         const provOpts = providers.map((p) => '<option value="' + esc(p.id) + '"' + (p.id === state.provider ? ' selected' : '') + '>' + esc(p.label || p.id) + '</option>').join('');

--- a/static/v3/songs.js
+++ b/static/v3/songs.js
@@ -59,8 +59,8 @@
         artist: '', album: '',
         grouping: true,     // one card per song (multi-chart grouping); persisted
 
-        filters: { arr_has: [], arr_lacks: [], stem_has: [], stem_lacks: [], lyrics: '', tunings: [], mastery: [], match: [] },
-        page: 0, total: 0, loading: false, built: false, accuracy: {}, tuningNames: [],
+        filters: { arr_has: [], arr_lacks: [], stem_has: [], stem_lacks: [], lyrics: '', tunings: [], mastery: [], match: [], genre: [] },
+        page: 0, total: 0, loading: false, built: false, accuracy: {}, tuningNames: [], genres: [],
         artistCatalog: [], renderedHash: '',
         scrollBound: false,
         songsById: {}, selectMode: false, selected: new Set(),
@@ -110,7 +110,7 @@
         const f = state.filters;
         return f.arr_has.length + f.arr_lacks.length + f.stem_has.length + f.stem_lacks.length +
             (f.lyrics ? 1 : 0) + f.tunings.length + (f.mastery ? f.mastery.length : 0) +
-            (f.match ? f.match.length : 0) +
+            (f.match ? f.match.length : 0) + (f.genre ? f.genre.length : 0) +
             (state.artist ? 1 : 0) + (state.album ? 1 : 0);
     }
 
@@ -135,6 +135,7 @@
                 tunings: [...(f.tunings || [])].sort(),
                 mastery: [...(f.mastery || [])].sort(),
                 match: [...(f.match || [])].sort(),
+                genre: [...(f.genre || [])].sort(),
             },
         });
     }
@@ -271,6 +272,7 @@
         if (f.tunings.length) p.set('tunings', f.tunings.join(','));
         if (f.mastery && f.mastery.length) p.set('mastery', f.mastery.join(','));
         if (f.match && f.match.length) p.set('match', f.match.join(','));
+        if (f.genre && f.genre.length) p.set('genre', f.genre.join(','));
         Object.entries(extra || {}).forEach(([k, v]) => p.set(k, v));
         return p;
     }
@@ -2040,6 +2042,8 @@
             // Match (P8) — the song's metadata-match lifecycle state, a triage
             // facet for the enrichment layer. Session-only, like Progress.
             section('Match', [['review', 'To review'], ['matched', 'Matched'], ['unmatched', 'Unmatched'], ['pending', 'Not scanned']].map((it) => '<button data-match="' + it[0] + '" class="px-2 py-1 rounded-md text-xs border ' + (f.match.includes(it[0]) ? 'bg-fb-primary text-white border-fb-primary' : 'bg-gray-800/50 text-fb-textDim border-gray-700') + '">' + it[1] + '</button>').join('')) +
+            // Genre facet — dynamic list from /api/library/genres (primary genre).
+            (state.genres && state.genres.length ? section('Genre', state.genres.map((g) => '<button data-genre="' + esc(g) + '" class="px-2 py-1 rounded-md text-xs border ' + (f.genre.includes(g) ? 'bg-fb-primary text-white border-fb-primary' : 'bg-gray-800/50 text-fb-textDim border-gray-700') + '">' + esc(g) + '</button>').join('')) : '') +
             section('Tuning', (state.tuningNames || []).map((t) => {
                 // Filter on the server's grouping key (raw offsets for customs)
                 // so two "Custom Tuning" entries are distinct; show their target
@@ -2092,11 +2096,12 @@
             reload();     // re-fetches grid + rail with/without group=1, saves prefs
         });
         d.querySelectorAll('[data-match]').forEach((b) => b.addEventListener('click', () => { const v = b.getAttribute('data-match'); const i = f.match.indexOf(v); if (i >= 0) f.match.splice(i, 1); else f.match.push(v); renderDrawer(); }));
+        d.querySelectorAll('[data-genre]').forEach((b) => b.addEventListener('click', () => { const v = b.getAttribute('data-genre'); const i = f.genre.indexOf(v); if (i >= 0) f.genre.splice(i, 1); else f.genre.push(v); renderDrawer(); }));
         d.querySelector('[data-drawer-save]')?.addEventListener('click', saveCurrentAsCollection);
         d.querySelector('[data-drawer-tidy]')?.addEventListener('click', openArtistTidyUp);
         d.querySelector('[data-drawer-close]')?.addEventListener('click', closeDrawer);
         d.querySelector('[data-drawer-clear]')?.addEventListener('click', async () => {
-            state.filters = { arr_has: [], arr_lacks: [], stem_has: [], stem_lacks: [], lyrics: '', tunings: [], mastery: [], match: [] };
+            state.filters = { arr_has: [], arr_lacks: [], stem_has: [], stem_lacks: [], lyrics: '', tunings: [], mastery: [], match: [], genre: [] };
             state.artist = '';
             state.album = '';
             renderDrawer();
@@ -2543,6 +2548,7 @@
             loadArtistCatalog(),
         ]);
         state.tuningNames = (tn && tn.tunings) || [];
+        try { const _g = await jget('/api/library/genres'); state.genres = (_g && _g.genres) || []; } catch (e) { state.genres = []; }
 
         const opt = (arr, sel) => arr.map(([v, l]) => '<option value="' + esc(v) + '"' + (v === sel ? ' selected' : '') + '>' + esc(l) + '</option>').join('');
         const provOpts = providers.map((p) => '<option value="' + esc(p.id) + '"' + (p.id === state.provider ? ' selected' : '') + '>' + esc(p.label || p.id) + '</option>').join('');


### PR DESCRIPTION
Adds a **Genre** filter facet to the library, now that the spec's `genres` field is merged (#40).

## Change
- **Server:** a `genre` column on `songs` (idempotent ALTER + index), written from the sloppak manifest's **`genres`** list on scan (**primary genre = `genres[0]`**); a genre band in `_build_where` (OR within the selected set, threaded like the mastery filter — a separate `query_page` kwarg, so `query_artists`/`query_stats` are unaffected); and **`GET /api/library/genres`** for the facet's distinct list.
- **Client:** a multi-select **Genre** section in the Filters drawer, mirroring the tuning/mastery facets (fetch list → pills → params/count/persistence-hash).

## v1 scope + coverage
Stores/filters only the **primary** genre (`genres[0]`); matching secondary genres is a follow-up. Genre filters the grid view. Needs a **rescan** to backfill; only packs whose manifest actually carries `genres` populate (a coverage reality, not a bug).

## Verification (live server)
A `.sloppak` tagged `genres: [Metal, Rock]`, plus a plain one:
- `/api/library/genres` → `["Metal"]`
- `?genre=Metal` → the tagged song (total 1); `?genre=Rock` (secondary) → none; the plain song stays ungenred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbexxfTt8q2tAn436MqGWF
