### PR TITLE
fix: restore .feedpak in the upload file-picker accept filter

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -72,7 +72,7 @@
 
     <!-- Hidden file input shared by the navbar "Upload" link. Kept at body
          level so it stays reachable regardless of which screen is active. -->
-    <input type="file" id="upload-songs-file" accept=".sloppak" multiple class="hidden" onchange="uploadSongs(this.files); this.value=''">
+    <input type="file" id="upload-songs-file" accept=".feedpak,.sloppak" multiple class="hidden" onchange="uploadSongs(this.files); this.value=''">
 
     <!-- ══ HOME (Hero + Library) ══════════════════════════════════════════ -->
     <div id="home" class="screen active">


### PR DESCRIPTION
An upstream `index.html` edit reverted the upload input's `accept` attribute (from PR #530) back to `.sloppak` only. The client-side JS filter and the server's `_ALLOWED_SONG_EXTS` (via `sloppak_mod.SONG_EXTS`) both still accept `.feedpak` — so the only symptom was the OS file-picker dialog hiding `.feedpak` files. One-line restore to `accept=".feedpak,.sloppak"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)