### PR TITLE
3D Drum Highway: enlarge note gems ~20% for readability

### DIFF
--- a/plugins/drum_highway_3d/screen.js
+++ b/plugins/drum_highway_3d/screen.js
@@ -83,10 +83,15 @@
 
     // Note dimensions (world units). All keyed to K so scale changes
     // propagate.
-    const DISC_R_BASE = 3.6 * K;                   // drum disc radius
-    const DISC_H = 1.2 * K;                        // drum disc thickness
-    const CYMBAL_R = 3.0 * K;                      // cymbal gem radius
-    const CYMBAL_H = 1.6 * K;                      // cymbal gem height
+    // Bumped ~20% (3.6/3.0 → 4.3/3.6) after hands-on feedback: the gems
+    // were hard to read at the default camera. Accent scale (1.25×) still
+    // fits the 12*K lane gap: 4.3*2*1.25 = 10.75. Every dependent shape
+    // (halo/ghost/open rings, snare stripe, bell dot, flam grace) keys off
+    // these radii, so the whole family scales together.
+    const DISC_R_BASE = 4.3 * K;                   // drum disc radius
+    const DISC_H = 1.4 * K;                        // drum disc thickness
+    const CYMBAL_R = 3.6 * K;                      // cymbal gem radius
+    const CYMBAL_H = 1.9 * K;                      // cymbal gem height
 
     // ─── Piece vocabulary (mirrors lib/drums.py PIECES) ──────────────
     // Used for kit configuration: user picks which of these pieces they


### PR DESCRIPTION
Hands-on feedback from testing the parity epic with a real drum chart (Arcturus — Kinetic): the gems were hard to read at the default camera.

- Disc radius 3.6 → 4.3, cymbal 3.0 → 3.6 world units (heights up proportionally)
- Every variant shape (accent halos, ghost/open-hat rings, snare wires, bell dots, flam grace) keys off the same radii, so the family scales together
- Accented discs (1.25×) still fit the 12·K lane gap (10.75 < 12)
- Screenshot-verified against the real chart; `node --test`: 15/15; Codex preflight clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)