### PR TITLE
test(v3): sync A–Z rail assertion to the railParams refactor (#702)

### DIFF
--- a/tests/js/v3_az_rail.test.js
+++ b/tests/js/v3_az_rail.test.js
@@ -44,7 +44,7 @@ test('refreshRail reads present letters from the stats endpoint (sort-aware)', (
     assert.match(src, /\/api\/library\/stats\?'\s*\+\s*queryParams/,
         'refreshRail must query /api/library/stats with the active filter params');
     // Opts into the active-sort breakdown so non-rail callers skip the scan.
-    assert.match(src, /queryParams\(\{\s*sort_letters:\s*1\s*\}\)/,
+    assert.match(src, /railParams\s*=\s*\{\s*sort_letters:\s*1\s*\}/,
         'refreshRail must request the sort_letters breakdown');
     assert.match(src, /letters\s*=\s*stats\s*&&\s*stats\.sort_letters/,
         'refreshRail must prefer the active-sort breakdown (sort_letters)');


### PR DESCRIPTION
The `v3_az_rail.test.js` "sort-aware" source-assertion went red on main after PR #702 (work grouping) refactored `refreshRail` from an inline `queryParams({ sort_letters: 1 })` to a `railParams = { sort_letters: 1 }` object (so it can add `group` when grouping is active). Behaviour is unchanged — the rail still opts into the active-sort breakdown and fetches `/api/library/stats?…sort_letters=1`. This points the assertion at the new shape. 9/9 green.

Surfaced while merging the v3-library PR stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)