### PR TITLE
fix(v3): drawer fav-sync honours data-fav-idle (no dim-heart on List View)

### DIFF
--- a/static/v3/songs.js
+++ b/static/v3/songs.js
@@ -2354,7 +2354,12 @@
         document.querySelectorAll('[data-fn="' + sel + '"] [data-fav]').forEach((btn) => {
             btn.textContent = fav ? '♥' : '♡';
             btn.setAttribute('aria-pressed', fav ? 'true' : 'false');
-            btn.classList.toggle('text-fb-accent', fav); btn.classList.toggle('text-white', !fav);
+            // Swap exactly the idle colour this heart was rendered with (grid =
+            // text-white, tree/List view = text-fb-textDim) — mirrors wireCards.
+            // A hardcoded text-white toggle would leave List-View rows' text-fb-textDim
+            // in place, so the heart changed glyph but stayed dim (never turned red).
+            const idle = btn.getAttribute('data-fav-idle') || 'text-white';
+            btn.classList.toggle('text-fb-accent', fav); btn.classList.toggle(idle, !fav);
         });
     }
 

--- a/tests/js/v3_favorites_toggle.test.js
+++ b/tests/js/v3_favorites_toggle.test.js
@@ -40,6 +40,16 @@ test('the shared fav handler swaps the declared idle colour, not a hardcoded one
         'the hardcoded text-white idle toggle must be removed');
 });
 
+test('the drawer fav-sync (_patchCardFav) swaps the declared idle colour too', () => {
+    // Toggling the like from the Song Details drawer patches the rendered card's
+    // heart via _patchCardFav; it must honour each heart's data-fav-idle the same
+    // way the click handler does, or List-View rows keep the dim-heart bug (#654).
+    assert.match(src, /function _patchCardFav[\s\S]*?getAttribute\('data-fav-idle'\)[\s\S]*?classList\.toggle\(\s*idle\s*,\s*!fav\s*\)/,
+        '_patchCardFav must restore the per-context idle colour (idle), not a hardcoded text-white');
+    assert.doesNotMatch(src, /classList\.toggle\('text-white',\s*!fav\)/,
+        '_patchCardFav must not hardcode the text-white idle toggle');
+});
+
 test('the fav toggle keeps the in-memory song model in sync', () => {
     // So a virtualized grid recycle / tree re-render renders the new state,
     // not a stale favorite=false read from state.songsById.


### PR DESCRIPTION
Follow-up to #654 (found while merging the v3-library stack). #703's Song Details drawer syncs a like back to the rendered card via `_patchCardFav`, which hardcoded `classList.toggle('text-white', !fav)`. On a List-View row (idle `text-fb-textDim`) that leaves the dim class in place, so favoriting from the drawer changes the glyph but the heart stays grey — the same bug #654 fixed for the on-card click handler, on a different code path.

Fix: read the heart's `data-fav-idle` and swap exactly that class, mirroring `wireCards`. Adds a regression assertion; `v3_favorites_toggle.test.js` 4/4 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)