### PR TITLE
v3: rename sidebar "Songs" entry to "Song Library"

### DIFF
--- a/static/v3/shell.js
+++ b/static/v3/shell.js
@@ -36,7 +36,7 @@
         { key: 'plugins',    screen: 'v3-plugins',       label: 'Plugins',         group: 'HOME',    icon: 'plug' },
         { key: 'settings',   screen: 'settings',         label: 'Settings',        group: 'HOME',    icon: 'gear' },
         { key: 'playlists',  screen: 'v3-playlists',     label: 'Playlists',       group: 'LIBRARY', icon: 'list' },
-        { key: 'songs',      screen: 'v3-songs',         label: 'Songs',           group: 'LIBRARY', icon: 'disc' },
+        { key: 'songs',      screen: 'v3-songs',         label: 'Song Library',    group: 'LIBRARY', icon: 'disc' },
         { key: 'lessons',    screen: 'v3-lessons',       label: 'Lessons',         group: 'LIBRARY', icon: 'lessons' },
         { key: 'favorites',  screen: 'favorites',        label: 'Favorites',       group: 'LIBRARY', icon: 'star' },
         { key: 'saved',      screen: 'v3-saved',         label: 'Saved for Later', group: 'LIBRARY', icon: 'bookmark' },


### PR DESCRIPTION
## What

One-word rename of the v3 sidebar's LIBRARY entry: **Songs → Song Library**. The topbar page title follows automatically (it mirrors nav labels via `titleFor()`).

## Why

"Song Library" says what the screen is — the full local library with search/filters/collections — and distinguishes it from Playlists/Favorites/Saved, which are also lists of songs.

## Scope guard

Label only. The nav `key: 'songs'` and `screen: 'v3-songs'` ids are unchanged, so `#songs` hash routing, saved navigation state, and the promoted-plugin `anchorAfter: 'songs'` slot are all untouched. No tests reference the label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm7tHs1Yvjjtnnu4nzJgdN