### PR TITLE
library: scraper options — per-source + per-field auto-apply, review-queue order (R1)

### DIFF
--- a/server.py
+++ b/server.py
@@ -874,9 +874,18 @@ class MetadataDB:
         # MusicBrainz just to render; `last_attempt_at` anchors the failed-row
         # retry backoff (epoch seconds). Idempotent ALTERs, same pattern as
         # the `songs` migrations above.
+        # R1 scraper options: `apply_mask` records which per-field auto-apply
+        # toggles were OFF (suppressed) when an AUTOMATIC match settled the row,
+        # as a canonical sorted comma-joined marker of blocked keys (''/NULL =
+        # nothing suppressed). It keeps the per-field toggles to the same
+        # "nothing forfeited" contract as the source/art toggles: re-enabling a
+        # field re-queues affected `matched` rows for backfill (enrichment_pending)
+        # and a partially-applied row is barred from seeding siblings
+        # (enrichment_cache_lookup). Idempotent ALTER, same pattern as above.
         for ddl in (
             "ALTER TABLE song_enrichment ADD COLUMN candidates TEXT",
             "ALTER TABLE song_enrichment ADD COLUMN last_attempt_at REAL",
+            "ALTER TABLE song_enrichment ADD COLUMN apply_mask TEXT",
         ):
             try:
                 self.conn.execute(ddl)
@@ -2621,7 +2630,8 @@ class MetadataDB:
         raw = "|".join([norm(artist), norm(title), norm(album), dur])
         return hashlib.sha1(raw.encode("utf-8")).hexdigest()
 
-    def enrichment_pending(self, limit: int = 500) -> list[dict]:
+    def enrichment_pending(self, limit: int = 500,
+                           allowed_keys: frozenset | None = None) -> list[dict]:
         """Songs whose enrichment row needs (re)matching: no row yet, or a
         row whose content_hash no longer matches the song's current metadata
         (an edit changed the identity → re-match), or an `unscanned` row.
@@ -2631,24 +2641,37 @@ class MetadataDB:
         retries only via the matcher's backoff policy (enrichment_failed_rows)
         rather than being re-queued every pass. An identity edit (say, the
         user fixes the typo that made matching fail) re-queues any of them
-        immediately via the hash mismatch."""
+        immediately via the hash mismatch.
+
+        `allowed_keys` is the set of per-field auto-apply toggle keys that are
+        currently ON. A `matched` row stamped while one of those fields was
+        suppressed (its key in `apply_mask`) is re-queued for backfill, so
+        re-enabling a field honours the same "nothing forfeited" contract the
+        source/art toggles already keep. None = don't apply the mask rule (the
+        caller isn't the field-aware matcher, e.g. a plain count)."""
         # Read under _lock: the worker commits on this shared connection under
         # _lock, so an unlocked SELECT could interleave with its execute+commit.
         with self._lock:
             rows = self.conn.execute(
                 "SELECT s.filename, s.artist, s.title, s.album, s.year, s.duration, "
-                "e.content_hash, e.match_state "
+                "e.content_hash, e.match_state, e.apply_mask "
                 "FROM songs s LEFT JOIN song_enrichment e ON e.filename = s.filename "
                 "WHERE s.title != '' AND (e.filename IS NULL "
                 "OR e.match_state IN ('unscanned', 'matched', 'review', 'failed')) "
                 "ORDER BY s.filename LIMIT ?", (max(1, int(limit)),)).fetchall()
         out = []
-        for fn, artist, title, album, year, duration, ehash, state in rows:
+        for fn, artist, title, album, year, duration, ehash, state, mask in rows:
             h = self.enrichment_content_hash(artist, title, album, duration)
             # No row yet, still unmatched, or the identity changed under a
             # settled row → needs the matcher. A settled row with an
-            # unchanged hash stays settled (idempotence).
-            if state is None or state == "unscanned" or ehash != h:
+            # unchanged hash stays settled (idempotence)…
+            needs = state is None or state == "unscanned" or ehash != h
+            # …EXCEPT a `matched` row that suppressed a field now re-enabled:
+            # re-queue it so the newly-allowed field gets backfilled.
+            if not needs and state == "matched" and allowed_keys is not None and mask:
+                if {k for k in mask.split(",") if k} & allowed_keys:
+                    needs = True
+            if needs:
                 out.append({"filename": fn, "artist": artist, "title": title,
                             "album": album, "year": year, "duration": duration,
                             "content_hash": h, "match_state": state})
@@ -2703,7 +2726,8 @@ class MetadataDB:
                 "SELECT filename, content_hash, match_state, match_source, match_score, attempts, "
                 "mb_recording_id, mb_release_id, mb_artist_id, isrc, "
                 "canon_artist, canon_album, canon_title, canon_year, canon_artist_sort, "
-                "genres, art_cache_path, art_state, fetched_at, candidates, last_attempt_at "
+                "genres, art_cache_path, art_state, fetched_at, candidates, last_attempt_at, "
+                "apply_mask "
                 "FROM song_enrichment WHERE filename = ?", (filename,)).fetchone()
         if not row:
             return None
@@ -2711,7 +2735,7 @@ class MetadataDB:
                 "attempts", "mb_recording_id", "mb_release_id", "mb_artist_id", "isrc",
                 "canon_artist", "canon_album", "canon_title", "canon_year",
                 "canon_artist_sort", "genres", "art_cache_path", "art_state", "fetched_at",
-                "candidates", "last_attempt_at")
+                "candidates", "last_attempt_at", "apply_mask")
         out = dict(zip(keys, row))
         for k in ("genres", "candidates"):
             try:
@@ -2763,12 +2787,17 @@ class MetadataDB:
     def enrichment_cache_lookup(self, content_hash: str, exclude_filename: str = "") -> dict | None:
         """A settled match for the same identity hash — another chart of the
         same recording already matched/pinned → copy it, no network (design
-        §5 step 1: the local match-cache)."""
+        §5 step 1: the local match-cache). Only FULLY-applied donors qualify
+        (apply_mask empty/NULL): a row that suppressed a display field under an
+        auto-apply toggle would otherwise seed siblings with its blanks even
+        when the reader's own toggles want that field — so a partial row is
+        skipped and the sibling falls through to its own (re-filtered) match."""
         row = self.conn.execute(
             "SELECT match_score, mb_recording_id, mb_release_id, mb_artist_id, isrc, "
             "canon_artist, canon_album, canon_title, canon_year, canon_artist_sort, genres "
             "FROM song_enrichment WHERE content_hash = ? AND filename != ? "
             "AND match_state IN ('matched', 'manual') AND mb_recording_id IS NOT NULL "
+            "AND COALESCE(apply_mask, '') = '' "
             "LIMIT 1", (content_hash, exclude_filename or "")).fetchone()
         if not row:
             return None
@@ -2788,7 +2817,8 @@ class MetadataDB:
                                source: str | None = None, score: float | None = None,
                                cand: dict | None = None, candidates: list | None = None,
                                bump_attempts: bool = False,
-                               allow_manual_overwrite: bool = False) -> bool:
+                               allow_manual_overwrite: bool = False,
+                               apply_mask: str | None = None) -> bool:
         """The single writer for every matcher/review outcome. Writes the
         full lifecycle row: state + source + score, the canonical fields a
         confident match supplies (`cand`), and/or the review tier's ranked
@@ -2796,7 +2826,11 @@ class MetadataDB:
         `manual` and the caller isn't explicitly acting for the user — the
         never-overwrite-manual contract lives HERE so no future call path
         can forget it. Art-cache fields are preserved verbatim (they belong
-        to the art slice, not the matcher)."""
+        to the art slice, not the matcher). `apply_mask` (blocked per-field
+        keys, from the matcher) is stamped verbatim so enrichment_pending /
+        enrichment_cache_lookup can tell a fully-applied match from a
+        field-suppressed one; the review/manual writers leave it NULL (a
+        confirmed pick applies in full)."""
         cand = cand or {}
         now = time.time()
         with self._lock:
@@ -2816,8 +2850,9 @@ class MetadataDB:
                 "match_state, match_source, match_score, attempts, "
                 "mb_recording_id, mb_release_id, mb_artist_id, isrc, "
                 "canon_artist, canon_album, canon_title, canon_year, canon_artist_sort, "
-                "genres, art_cache_path, art_state, fetched_at, candidates, last_attempt_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "genres, art_cache_path, art_state, fetched_at, candidates, last_attempt_at, "
+                "apply_mask) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (filename, content_hash, state, source, score, attempts,
                  cand.get("recording_id") or None, cand.get("release_id") or None,
                  cand.get("artist_id") or None, cand.get("isrc") or None,
@@ -2828,7 +2863,8 @@ class MetadataDB:
                  cur[2] if cur else None, cur[3] if cur else None,
                  fetched_at,
                  json.dumps(candidates) if candidates else None,
-                 now if state == "failed" else None))
+                 now if state == "failed" else None,
+                 apply_mask or None))
             self.conn.commit()
         return True
 
@@ -5877,6 +5913,21 @@ _ENRICH_APPLY_FIELDS = {
 }
 
 
+def _enrich_blocked_apply_keys(cfg: dict) -> frozenset:
+    """The per-field auto-apply toggle keys that are currently OFF (suppressed).
+    Its complement (`_ENRICH_APPLY_FIELDS` minus these) is what an automatic
+    match may canonicalize."""
+    return frozenset(k for k in _ENRICH_APPLY_FIELDS if cfg.get(k, True) is False)
+
+
+def _enrich_apply_mask(cfg: dict) -> str:
+    """Canonical marker of the suppressed apply keys, persisted on each
+    automatic match so re-enabling a field re-queues the row for backfill
+    (enrichment_pending) and a partial match can't seed siblings
+    (enrichment_cache_lookup). '' = nothing suppressed (the default)."""
+    return ",".join(sorted(_enrich_blocked_apply_keys(cfg)))
+
+
 def _enrich_field_filter(cfg: dict):
     """Build the cand filter for AUTOMATIC matches from the per-field
     auto-apply settings: strips the display fields whose toggle is off
@@ -5884,14 +5935,15 @@ def _enrich_field_filter(cfg: dict):
     on (the default) so the common path stays zero-copy. Review candidates
     and user-confirmed picks bypass this — a match the user confirms in
     the modal applies in full."""
-    blocked = {f for key, fields in _ENRICH_APPLY_FIELDS.items()
-               if cfg.get(key, True) is False for f in fields}
+    blocked = {f for key in _enrich_blocked_apply_keys(cfg)
+               for f in _ENRICH_APPLY_FIELDS[key]}
     if not blocked:
         return None
     return lambda cand: {k: v for k, v in cand.items() if k not in blocked}
 
 
-def _enrich_one(row: dict, auto_min: float | None = None, field_filter=None) -> None:
+def _enrich_one(row: dict, auto_min: float | None = None, field_filter=None,
+                apply_mask: str = "") -> None:
     """The matcher (P8; replaces P7's no-op). Precedence per design §5:
 
     1. local match-cache by content_hash — another chart of the same
@@ -5909,8 +5961,11 @@ def _enrich_one(row: dict, auto_min: float | None = None, field_filter=None) -> 
     from every AUTOMATIC stamp — all three steps here are automatic, so it
     applies to each; the review tier stores candidates unfiltered because
     accepting one is a user action. Never touches a `manual` row (the
-    writer enforces it). Network errors raise EnrichTransportError so the
-    pass pauses instead of burning attempts while offline."""
+    writer enforces it). `apply_mask` (the suppressed keys, from
+    _enrich_apply_mask) is stamped on each AUTOMATIC match so a later
+    re-enable re-queues the row for backfill and a partial match can't seed
+    siblings. Network errors raise EnrichTransportError so the pass pauses
+    instead of burning attempts while offline."""
     fn, chash = row["filename"], row["content_hash"]
 
     cached = meta_db.enrichment_cache_lookup(chash, exclude_filename=fn)
@@ -5919,7 +5974,7 @@ def _enrich_one(row: dict, auto_min: float | None = None, field_filter=None) -> 
         if field_filter:
             cached = field_filter(cached)
         meta_db.apply_enrichment_match(fn, chash, "matched", source="cache",
-                                       score=score, cand=cached)
+                                       score=score, cand=cached, apply_mask=apply_mask)
         return
 
     ids = _manifest_exact_ids(fn)
@@ -5927,7 +5982,7 @@ def _enrich_one(row: dict, auto_min: float | None = None, field_filter=None) -> 
         cand = _mb_lookup_recording(ids["mbid"])
         if cand:
             meta_db.apply_enrichment_match(fn, chash, "matched", source="mbid",
-                                           score=1.0,
+                                           score=1.0, apply_mask=apply_mask,
                                            cand=field_filter(cand) if field_filter else cand)
             return
         # A 404'd mbid (typo'd manifest) falls through to the text tiers.
@@ -5935,7 +5990,7 @@ def _enrich_one(row: dict, auto_min: float | None = None, field_filter=None) -> 
         cands = mb_match.rank_candidates(row, _mb_lookup_isrc(ids["isrc"]))
         if cands:
             meta_db.apply_enrichment_match(fn, chash, "matched", source="isrc",
-                                           score=1.0,
+                                           score=1.0, apply_mask=apply_mask,
                                            cand=field_filter(cands[0]) if field_filter else cands[0])
             return
 
@@ -5944,7 +5999,7 @@ def _enrich_one(row: dict, auto_min: float | None = None, field_filter=None) -> 
     tier = mb_match.classify(row, best, best["score"], auto_min=auto_min) if best else "none"
     if tier == "auto":
         meta_db.apply_enrichment_match(fn, chash, "matched", source="text",
-                                       score=best["score"],
+                                       score=best["score"], apply_mask=apply_mask,
                                        cand=field_filter(best) if field_filter else best)
     elif tier == "review":
         meta_db.apply_enrichment_match(fn, chash, "review", source="text",
@@ -5967,8 +6022,15 @@ def _background_enrich():
     (kill-switch or the test env) skips phase 2 entirely. Never drains in a
     loop — a dead network would make that spin forever."""
     _enrich_status["processed"] = 0
+    # User settings gate the BACKGROUND matcher only (the review modal's
+    # manual search/fix stays available when it's off); read once per pass,
+    # up front so the pending query can honour the per-field apply mask
+    # (a re-enabled field re-queues its `matched` rows for backfill).
+    cfg = _load_config(CONFIG_DIR / "config.json") or {}
+    allowed_keys = frozenset(_ENRICH_APPLY_FIELDS) - _enrich_blocked_apply_keys(cfg)
+    apply_mask = _enrich_apply_mask(cfg)
     try:
-        pending = meta_db.enrichment_pending(limit=100000)
+        pending = meta_db.enrichment_pending(limit=100000, allowed_keys=allowed_keys)
     except Exception:
         log.exception("enrichment: pending query failed")
         return
@@ -5980,9 +6042,6 @@ def _background_enrich():
         _enrich_status["processed"] += 1
     _enrich_status["last_pass_at"] = time.time()
 
-    # User settings gate the BACKGROUND matcher only (the review modal's
-    # manual search/fix stays available when it's off); read once per pass.
-    cfg = _load_config(CONFIG_DIR / "config.json") or {}
     if cfg.get("enrich_enabled", True) is False:
         if pending:
             log.info("Enrichment pass: %d rows stamped (matching disabled in Settings)", len(pending))
@@ -6029,7 +6088,8 @@ def _background_enrich():
         queue.append(row)
     for row in queue:
         try:
-            _enrich_one(row, auto_min=auto_min, field_filter=field_filter)
+            _enrich_one(row, auto_min=auto_min, field_filter=field_filter,
+                        apply_mask=apply_mask)
             matched += 1
         except EnrichTransportError as e:
             log.info("enrichment: network unavailable, pass paused (%s)", e)

--- a/server.py
+++ b/server.py
@@ -2858,19 +2858,26 @@ class MetadataDB:
             filename, row["content_hash"], "failed", source="rejected",
             score=None, candidates=row.get("candidates") or None)
 
-    def enrichment_review_queue(self, limit: int = 200) -> list[dict]:
+    def enrichment_review_queue(self, limit: int = 200,
+                                order: str = "missing_first") -> list[dict]:
         """The Match-Review drawer's queue: review-tier rows joined to their
-        (still-existing) songs, with the stored candidate list parsed."""
+        (still-existing) songs, with the stored candidate list parsed.
+        `order` is the user's review-queue preference: 'missing_first'
+        (default — charts missing album/year surface first, they gain the
+        most from a confirm; complete charts only stand to be re-labelled),
+        'artist' (A–Z), or 'recent' (newest files first). Unknown values
+        fall back to missing_first."""
+        order_sql = {
+            "artist": "s.artist COLLATE NOCASE, s.title COLLATE NOCASE, e.filename",
+            "recent": "s.mtime DESC, e.filename",
+        }.get(order, "((COALESCE(s.album, '') = '') + (COALESCE(s.year, '') = '')) DESC, "
+                     "s.artist COLLATE NOCASE, s.title COLLATE NOCASE, e.filename")
         rows = self.conn.execute(
             "SELECT e.filename, s.title, s.artist, s.album, s.year, s.duration, s.mtime, "
             "e.match_score, e.candidates, e.attempts "
             "FROM song_enrichment e JOIN songs s ON s.filename = e.filename "
             "WHERE e.match_state = 'review' "
-            # Charts that are MISSING data (no album / no year) surface first —
-            # confirming those has the most to gain; complete charts only
-            # stand to be re-labelled.
-            "ORDER BY ((COALESCE(s.album, '') = '') + (COALESCE(s.year, '') = '')) DESC, "
-            "s.artist COLLATE NOCASE, s.title COLLATE NOCASE, e.filename "
+            "ORDER BY " + order_sql + " "
             "LIMIT ?", (max(1, int(limit)),)).fetchall()
         out = []
         for fn, title, artist, album, year, duration, mtime, score, cands, attempts in rows:
@@ -5859,7 +5866,32 @@ def _enrich_art_one(row: dict) -> bool:
     return True
 
 
-def _enrich_one(row: dict, auto_min: float | None = None) -> None:
+_ENRICH_APPLY_FIELDS = {
+    # Per-field auto-apply toggle → the candidate fields it governs. The
+    # MusicBrainz ids + isrc are deliberately NOT here: they're identity,
+    # not display — the art fetch and any future re-match need them stamped
+    # even when every display field is toggled off.
+    "enrich_apply_names": ("artist", "title", "album", "artist_sort"),
+    "enrich_apply_year": ("year",),
+    "enrich_apply_genres": ("genres",),
+}
+
+
+def _enrich_field_filter(cfg: dict):
+    """Build the cand filter for AUTOMATIC matches from the per-field
+    auto-apply settings: strips the display fields whose toggle is off
+    before they're stamped as canonical. Returns None when everything is
+    on (the default) so the common path stays zero-copy. Review candidates
+    and user-confirmed picks bypass this — a match the user confirms in
+    the modal applies in full."""
+    blocked = {f for key, fields in _ENRICH_APPLY_FIELDS.items()
+               if cfg.get(key, True) is False for f in fields}
+    if not blocked:
+        return None
+    return lambda cand: {k: v for k, v in cand.items() if k not in blocked}
+
+
+def _enrich_one(row: dict, auto_min: float | None = None, field_filter=None) -> None:
     """The matcher (P8; replaces P7's no-op). Precedence per design §5:
 
     1. local match-cache by content_hash — another chart of the same
@@ -5872,15 +5904,20 @@ def _enrich_one(row: dict, auto_min: float | None = None) -> None:
 
     `auto_min` is the user's auto-apply confidence setting (None → the
     engine default); it moves only the auto/review boundary of step 3 —
-    the per-field floors and exact-key tiers are unaffected. Never touches
-    a `manual` row (the writer enforces it). Network errors raise
-    EnrichTransportError so the pass pauses instead of burning attempts
-    while offline."""
+    the per-field floors and exact-key tiers are unaffected. `field_filter`
+    (from _enrich_field_filter) strips per-field-disabled display values
+    from every AUTOMATIC stamp — all three steps here are automatic, so it
+    applies to each; the review tier stores candidates unfiltered because
+    accepting one is a user action. Never touches a `manual` row (the
+    writer enforces it). Network errors raise EnrichTransportError so the
+    pass pauses instead of burning attempts while offline."""
     fn, chash = row["filename"], row["content_hash"]
 
     cached = meta_db.enrichment_cache_lookup(chash, exclude_filename=fn)
     if cached:
         score = cached.pop("score", None)
+        if field_filter:
+            cached = field_filter(cached)
         meta_db.apply_enrichment_match(fn, chash, "matched", source="cache",
                                        score=score, cand=cached)
         return
@@ -5890,14 +5927,16 @@ def _enrich_one(row: dict, auto_min: float | None = None) -> None:
         cand = _mb_lookup_recording(ids["mbid"])
         if cand:
             meta_db.apply_enrichment_match(fn, chash, "matched", source="mbid",
-                                           score=1.0, cand=cand)
+                                           score=1.0,
+                                           cand=field_filter(cand) if field_filter else cand)
             return
         # A 404'd mbid (typo'd manifest) falls through to the text tiers.
     if ids.get("isrc"):
         cands = mb_match.rank_candidates(row, _mb_lookup_isrc(ids["isrc"]))
         if cands:
             meta_db.apply_enrichment_match(fn, chash, "matched", source="isrc",
-                                           score=1.0, cand=cands[0])
+                                           score=1.0,
+                                           cand=field_filter(cands[0]) if field_filter else cands[0])
             return
 
     ranked = mb_match.rank_candidates(row, _mb_search_recordings(row.get("artist"), row.get("title")))
@@ -5905,7 +5944,8 @@ def _enrich_one(row: dict, auto_min: float | None = None) -> None:
     tier = mb_match.classify(row, best, best["score"], auto_min=auto_min) if best else "none"
     if tier == "auto":
         meta_db.apply_enrichment_match(fn, chash, "matched", source="text",
-                                       score=best["score"], cand=best)
+                                       score=best["score"],
+                                       cand=field_filter(best) if field_filter else best)
     elif tier == "review":
         meta_db.apply_enrichment_match(fn, chash, "review", source="text",
                                        score=best["score"],
@@ -5957,19 +5997,31 @@ def _background_enrich():
             log.info("Enrichment pass: %d rows stamped (network disabled — matching skipped)", len(pending))
         return
 
+    # Scraper options (R1), read from the same per-pass cfg: `mb_on` gates
+    # the matcher (phase 2), `art_on` the cover-art fetch (phase 3 — the
+    # Cover Art Archive is the only automatic art source today, so the
+    # source toggle and the cover-art apply toggle both have to be on).
+    mb_on = cfg.get("enrich_src_musicbrainz", True) is not False
+    art_on = (cfg.get("enrich_src_caa", True) is not False
+              and cfg.get("enrich_apply_art", True) is not False)
+    field_filter = _enrich_field_filter(cfg)
+
     now = time.time()
     retriable = []
-    try:
-        retriable = [r for r in meta_db.enrichment_failed_rows(limit=100000)
-                     if _enrich_backoff_elapsed(r.get("attempts"), r.get("last_attempt_at"), now)]
-    except Exception:
-        log.exception("enrichment: failed-row query failed")
+    if mb_on:
+        try:
+            retriable = [r for r in meta_db.enrichment_failed_rows(limit=100000)
+                         if _enrich_backoff_elapsed(r.get("attempts"), r.get("last_attempt_at"), now)]
+        except Exception:
+            log.exception("enrichment: failed-row query failed")
+    elif pending:
+        log.info("Enrichment pass: %d rows stamped (MusicBrainz source disabled in Settings)", len(pending))
     matched = 0
     # A `failed` row with a changed identity hash can surface in BOTH lists;
     # de-dup by filename so each row consumes the rate budget only once.
     seen_filenames = set()
     queue = []
-    for row in pending + retriable:
+    for row in (pending + retriable) if mb_on else []:
         fn = row.get("filename")
         if fn in seen_filenames:
             continue
@@ -5977,7 +6029,7 @@ def _background_enrich():
         queue.append(row)
     for row in queue:
         try:
-            _enrich_one(row, auto_min=auto_min)
+            _enrich_one(row, auto_min=auto_min, field_filter=field_filter)
             matched += 1
         except EnrichTransportError as e:
             log.info("enrichment: network unavailable, pass paused (%s)", e)
@@ -5992,7 +6044,7 @@ def _background_enrich():
                     source="error", bump_attempts=True)
             except Exception:
                 pass
-    if pending or retriable:
+    if mb_on and (pending or retriable):
         log.info("Enrichment pass: %d rows stamped, %d matched", len(pending), matched)
 
     # Phase 3 — cover art (R3/P9). For freshly-matched songs, resolve the art
@@ -6000,6 +6052,10 @@ def _background_enrich():
     # marked and skipped; the rest fetch the release's front cover from the
     # Cover Art Archive into the size-capped cache. Same pause-on-transport-
     # error rule as matching — a dead network never burns a row's evaluation.
+    # Rows skipped here stay art_state NULL, so re-enabling the toggles picks
+    # them up on the next pass — nothing is permanently forfeited.
+    if not art_on:
+        return
     try:
         art_rows = meta_db.enrichment_art_pending(limit=100000)
     except Exception:
@@ -6546,10 +6602,13 @@ def api_enrichment_kick():
 def api_enrichment_review(limit: int = 200):
     """The Match-Review queue: songs whose text match landed in the medium-
     confidence review tier, each with its stored candidate list — the drawer
-    renders straight from this, no MusicBrainz round-trip."""
+    renders straight from this, no MusicBrainz round-trip. Ordered by the
+    user's enrich_review_order setting."""
     limit = max(1, min(int(limit), 500))
+    cfg = _load_config(CONFIG_DIR / "config.json") or {}
+    order = cfg.get("enrich_review_order", "missing_first")
     return {
-        "songs": meta_db.enrichment_review_queue(limit=limit),
+        "songs": meta_db.enrichment_review_queue(limit=limit, order=order),
         "total_review": meta_db.enrichment_state_counts().get("review", 0),
     }
 
@@ -8773,6 +8832,22 @@ def _default_settings():
         # review" option) sends every text match to review.
         "enrich_enabled": True,
         "enrich_auto_threshold": 0.9,
+        # Scraper options (R1). Two axes, media-server style: sources say WHO
+        # may be contacted (MusicBrainz = the matcher, Cover Art Archive = the
+        # art fetch); the apply toggles say WHICH fields an AUTOMATIC match may
+        # canonicalize. A match the user confirms in the review modal always
+        # applies in full — these gate only what happens without them. All of
+        # it is display-side cache; nothing here ever writes to a pack file.
+        "enrich_src_musicbrainz": True,
+        "enrich_src_caa": True,
+        "enrich_apply_names": True,
+        "enrich_apply_year": True,
+        "enrich_apply_genres": True,
+        "enrich_apply_art": True,
+        # Review-queue ordering: missing_first = charts lacking album/year
+        # surface first (they gain the most), artist = A–Z, recent = newest
+        # files first.
+        "enrich_review_order": "missing_first",
     }
 
 
@@ -8943,6 +9018,21 @@ def save_settings(data: dict):
             if not math.isfinite(t) or not (0.5 <= t <= 1.01):
                 return {"error": "enrich_auto_threshold must be a number between 0.5 and 1.01"}
             updates["enrich_auto_threshold"] = t
+    for _bool_key in ("enrich_src_musicbrainz", "enrich_src_caa",
+                      "enrich_apply_names", "enrich_apply_year",
+                      "enrich_apply_genres", "enrich_apply_art"):
+        if _bool_key in data:
+            raw = data[_bool_key]
+            if raw is not None:
+                if not isinstance(raw, bool):
+                    return {"error": f"{_bool_key} must be a boolean"}
+                updates[_bool_key] = raw
+    if "enrich_review_order" in data:
+        raw = data["enrich_review_order"]
+        if raw is not None:
+            if not isinstance(raw, str) or raw not in ("missing_first", "artist", "recent"):
+                return {"error": "enrich_review_order must be one of missing_first, artist, recent"}
+            updates["enrich_review_order"] = raw
     if "miss_penalty" in data:
         raw = data["miss_penalty"]
         if raw is not None:

--- a/server.py
+++ b/server.py
@@ -240,6 +240,10 @@ _DEMO_BLOCKED: list[tuple[str, re.Pattern]] = [
     ("POST",   re.compile(r"^/api/enrichment/review/.+$")),
     ("POST",   re.compile(r"^/api/enrichment/kick$")),
     ("GET",    re.compile(r"^/api/enrichment/search$")),
+    # Art layer (R3): the URL fetch makes the server request arbitrary
+    # images on a visitor's behalf, and the override delete mutates state.
+    ("POST",   re.compile(r"^/api/song/.+/art/url$")),
+    ("DELETE", re.compile(r"^/api/art/.+/override$")),
 ]
 
 
@@ -2879,6 +2883,41 @@ class MetadataDB:
                         "mtime": mtime, "match_score": score,
                         "candidates": candidates, "attempts": attempts or 0})
         return out
+
+    def enrichment_art_pending(self, limit: int = 500) -> list[dict]:
+        """Matched songs whose cover-art situation hasn't been evaluated yet
+        (art_state NULL). The art worker resolves each to 'pack' (song has its
+        own art), 'user' (an override exists), 'caa' (fetched), 'none' (the
+        release has no cover) or 'error' — any of which settles the row, so
+        this never re-offers a song each pass."""
+        rows = self.conn.execute(
+            "SELECT e.filename, e.mb_release_id "
+            "FROM song_enrichment e JOIN songs s ON s.filename = e.filename "
+            "WHERE e.match_state IN ('matched', 'manual') "
+            "AND e.mb_release_id IS NOT NULL AND e.art_state IS NULL "
+            "ORDER BY e.filename LIMIT ?", (max(1, int(limit)),)).fetchall()
+        return [{"filename": r[0], "mb_release_id": r[1]} for r in rows]
+
+    def set_enrichment_art(self, filename: str, path: str | None, state: str | None) -> None:
+        """Stamp a row's art-cache outcome. Targeted UPDATE (not the match
+        writer) so it can never disturb the match lifecycle fields."""
+        with self._lock:
+            self.conn.execute(
+                "UPDATE song_enrichment SET art_cache_path = ?, art_state = ? "
+                "WHERE filename = ?", (path, state, filename))
+            self.conn.commit()
+
+    def clear_enrichment_art_paths(self, paths: list[str]) -> None:
+        """Reset rows whose cached art file was evicted (LRU prune) back to
+        unevaluated, so a later pass may re-fetch if the song still qualifies."""
+        if not paths:
+            return
+        with self._lock:
+            ph = ",".join("?" * len(paths))
+            self.conn.execute(
+                f"UPDATE song_enrichment SET art_cache_path = NULL, art_state = NULL "
+                f"WHERE art_cache_path IN ({ph})", paths)
+            self.conn.commit()
 
     def _estd_set(self) -> set[str]:
         """Get set of filenames that have a retuned variant (_EStd_ or _DropD_) in the DB."""
@@ -5694,6 +5733,131 @@ def _enrich_backoff_elapsed(attempts, last_attempt_at, now: float) -> bool:
 # handful is noise the user has to scroll past.
 _ENRICH_MAX_CANDIDATES = 5
 
+# ── Cover art (R3/P9) ─────────────────────────────────────────────────────────
+# The art cache dir (CONFIG_DIR/art_cache) holds two kinds of file:
+#   {safe_name}.png / .gif  — USER OVERRIDES (upload or URL-fetch; never
+#                             evicted, removed only with the song or by the
+#                             explicit remove-override route)
+#   caa_{release_mbid}.jpg  — COVER ART ARCHIVE fetches, keyed by release so
+#                             every chart of the same release shares one file;
+#                             size-capped LRU (evictions reset the enrichment
+#                             rows so a later pass may re-fetch)
+_CAA_CACHE_CAP_BYTES = 200 * 1024 * 1024
+
+
+def _caa_http_get(release_id: str) -> bytes | None:
+    """Fetch a release's front cover from the Cover Art Archive — the one
+    network seam of the art layer (tests fake exactly this). Same etiquette
+    as the MusicBrainz client: throttled, identified, offline-guarded.
+    Returns the image bytes, None when the release has no cover (404), and
+    raises EnrichTransportError for anything network-shaped."""
+    if not _enrich_network_enabled():
+        raise EnrichTransportError("enrichment network disabled")
+    import requests
+    _enrich_throttle()
+    try:
+        resp = requests.get(
+            f"https://coverartarchive.org/release/{release_id}/front-500",
+            headers={"User-Agent": _enrich_user_agent()},
+            timeout=15, allow_redirects=True,
+        )
+    except requests.RequestException as e:
+        raise EnrichTransportError(str(e)) from e
+    if resp.status_code == 404:
+        return None
+    if resp.status_code != 200:
+        raise EnrichTransportError(f"cover art archive HTTP {resp.status_code}")
+    return resp.content
+
+
+def _art_safe_name(filename: str) -> str:
+    """The flattened cache-file stem the art routes key user overrides on
+    (matches the legacy /art/upload naming, so old uploads keep working)."""
+    return filename.replace("/", "_").replace(" ", "_")
+
+
+def _art_override_paths(filename: str) -> list[Path]:
+    """Existing user-override art files for a song, GIF first (it wins —
+    the animated local-only bonus outranks a stale PNG)."""
+    stem = _art_safe_name(filename)
+    return [p for p in (ART_CACHE_DIR / f"{stem}.gif", ART_CACHE_DIR / f"{stem}.png")
+            if p.is_file()]
+
+
+def _song_pack_art_exists(filename: str) -> bool:
+    """Whether the song carries its own art (sloppak cover / loose-folder
+    image). Pack art always outranks a CAA fetch, so the art worker marks
+    these and never spends a request on them."""
+    try:
+        dlc = _get_dlc_dir()
+        if not dlc:
+            return False
+        p = _resolve_dlc_path(dlc, filename)
+        if p is None or not p.exists():
+            return False
+        if sloppak_mod.is_sloppak(p):
+            return sloppak_mod.read_cover_bytes(p) is not None
+        if loosefolder_mod.is_loose_song(p):
+            return loosefolder_mod.find_art(p) is not None
+    except Exception:
+        pass
+    return False
+
+
+def _prune_caa_cache() -> None:
+    """Keep the CAA side of the art cache under its size cap: evict the
+    oldest caa_* files (mtime LRU) and reset the enrichment rows that pointed
+    at them. User-override files are never touched."""
+    try:
+        files = sorted(ART_CACHE_DIR.glob("caa_*.jpg"), key=lambda p: p.stat().st_mtime)
+        total = sum(p.stat().st_size for p in files)
+        evicted: list[str] = []
+        while files and total > _CAA_CACHE_CAP_BYTES:
+            victim = files.pop(0)
+            try:
+                total -= victim.stat().st_size
+                victim.unlink()
+                evicted.append(str(victim))
+            except OSError:
+                break
+        if evicted:
+            meta_db.clear_enrichment_art_paths(evicted)
+            log.info("art cache: evicted %d cover(s) to stay under the cap", len(evicted))
+    except Exception:
+        log.exception("art cache prune failed")
+
+
+def _enrich_art_one(row: dict) -> bool:
+    """Resolve one matched song's cover-art situation (art worker, phase 3).
+    Returns True when a cover was actually fetched. Every outcome writes an
+    art_state so the row never re-queues:
+      'pack'  — the song ships its own art (it wins; nothing to do)
+      'user'  — an override exists (it wins; nothing to do)
+      'caa'   — front cover cached (possibly deduped from an earlier fetch
+                of the same release — no network on that path)
+      'none'  — the Cover Art Archive has no cover for this release
+    Network errors raise EnrichTransportError → the pass pauses and the row
+    stays unevaluated for the next kick."""
+    fn, release_id = row["filename"], row["mb_release_id"]
+    if _song_pack_art_exists(fn):
+        meta_db.set_enrichment_art(fn, None, "pack")
+        return False
+    if _art_override_paths(fn):
+        meta_db.set_enrichment_art(fn, None, "user")
+        return False
+    cache_file = _enrichment_art_dir() / f"caa_{release_id}.jpg"
+    if cache_file.is_file():
+        meta_db.set_enrichment_art(fn, str(cache_file), "caa")
+        return False
+    data = _caa_http_get(release_id)
+    if data is None:
+        meta_db.set_enrichment_art(fn, None, "none")
+        return False
+    cache_file.write_bytes(data)
+    meta_db.set_enrichment_art(fn, str(cache_file), "caa")
+    _prune_caa_cache()
+    return True
+
 
 def _enrich_one(row: dict, auto_min: float | None = None) -> None:
     """The matcher (P8; replaces P7's no-op). Precedence per design §5:
@@ -5830,6 +5994,32 @@ def _background_enrich():
                 pass
     if pending or retriable:
         log.info("Enrichment pass: %d rows stamped, %d matched", len(pending), matched)
+
+    # Phase 3 — cover art (R3/P9). For freshly-matched songs, resolve the art
+    # situation once: songs with their own pack art (or a user override) are
+    # marked and skipped; the rest fetch the release's front cover from the
+    # Cover Art Archive into the size-capped cache. Same pause-on-transport-
+    # error rule as matching — a dead network never burns a row's evaluation.
+    try:
+        art_rows = meta_db.enrichment_art_pending(limit=100000)
+    except Exception:
+        log.exception("enrichment: art-pending query failed")
+        return
+    fetched = 0
+    for row in art_rows:
+        try:
+            fetched += 1 if _enrich_art_one(row) else 0
+        except EnrichTransportError as e:
+            log.info("enrichment: network unavailable, art pass paused (%s)", e)
+            break
+        except Exception as e:
+            log.warning("enrichment art failed for %s: %s", row.get("filename"), e)
+            try:
+                meta_db.set_enrichment_art(row["filename"], None, "error")
+            except Exception:
+                pass
+    if art_rows:
+        log.info("Enrichment art pass: %d evaluated, %d covers fetched", len(art_rows), fetched)
 
 
 def _kick_enrich() -> bool:
@@ -6947,6 +7137,14 @@ def delete_song(filename: str):
             # on the explicit per-song delete — the never-clobber contract.
             meta_db.conn.execute("DELETE FROM song_enrichment WHERE filename = ?", (cache_key,))
             meta_db.conn.commit()
+
+        # User art overrides go with the song (CAA cache files are keyed by
+        # RELEASE and may be shared with other charts — the LRU owns those).
+        for _p in _art_override_paths(cache_key):
+            try:
+                _p.unlink()
+            except OSError:
+                pass
 
         _invalidate_song_caches(cache_key)
 
@@ -9938,14 +10136,17 @@ def _file_art_response(path: Path, media_type: str, request: Request | None):
 
 @app.get("/api/song/{filename:path}/art")
 async def get_song_art(filename: str, request: Request = None):
-    """Serve album art for a song.
+    """Serve album art for a song, walking the R3 override chain:
 
-    Dispatches by format and returns the appropriate media type:
-      - Sloppak: serves `cover.jpg` (or manifest-declared cover) read directly
-        from the package (the single cover member for zip-form sloppaks — no
-        full unpack) as JPEG/PNG/WebP.
-      - Loose folder: serves the discovered art file directly as
-        JPEG/PNG/WebP.
+      1. USER OVERRIDE (upload / URL-fetch, {safe_name}.gif|.png in the art
+         cache) — art the user explicitly pinned outranks everything, pack
+         art included. GIF is allowed HERE only: an animated cover is a
+         local-only bonus; packs stay jpg/png/webp and nothing ever writes
+         art into a pack file.
+      2. PACK ART — sloppak cover (single member read, no full unpack) or
+         the loose folder's discovered image.
+      3. COVER ART ARCHIVE cache — fetched by the enrichment art worker for
+         matched songs that lack pack art, keyed by release MBID.
     """
     dlc = _get_dlc_dir()
     if not dlc:
@@ -9957,7 +10158,12 @@ async def get_song_art(filename: str, request: Request = None):
     if not song_path.exists():
         return JSONResponse({"error": "not found"}, 404)
 
-    # Sloppak path: read the cover (manifest-declared or default) straight from
+    # 1. User override — GIF first (it wins over a stale PNG override).
+    for cached in _art_override_paths(filename):
+        mt = "image/gif" if cached.suffix == ".gif" else "image/png"
+        return _file_art_response(cached, mt, request)
+
+    # 2a. Sloppak: read the cover (manifest-declared or default) straight from
     # the package. For a zip-form sloppak this opens just the cover member —
     # NOT the whole archive — so the library grid never triggers a full unpack
     # of stems just to paint a thumbnail.
@@ -9972,18 +10178,17 @@ async def get_song_art(filename: str, request: Request = None):
             art = await asyncio.to_thread(sloppak_mod.read_cover_bytes, song_path)
         except Exception:
             art = None
-        if art is None:
-            return JSONResponse({"error": "no art"}, 404)
-        data, mt = art
-        etag = f'"{hashlib.sha1(data).hexdigest()}"'
-        headers, not_modified = _art_conditional(etag, request)
-        if not_modified:
-            return Response(status_code=304, headers=headers)
-        return Response(content=data, media_type=mt, headers=headers)
+        if art is not None:
+            data, mt = art
+            etag = f'"{hashlib.sha1(data).hexdigest()}"'
+            headers, not_modified = _art_conditional(etag, request)
+            if not_modified:
+                return Response(status_code=304, headers=headers)
+            return Response(content=data, media_type=mt, headers=headers)
 
-    # Loose folder path: serve art file directly.
+    # 2b. Loose folder: serve the discovered art file directly.
     # song_path is already validated against DLC_DIR by _resolve_dlc_path.
-    if loosefolder_mod.is_loose_song(song_path):
+    elif loosefolder_mod.is_loose_song(song_path):
         art_path = loosefolder_mod.find_art(song_path)
         if art_path:
             # Re-resolve in case the matched file is a symlink — a crafted
@@ -10000,15 +10205,13 @@ async def get_song_art(filename: str, request: Request = None):
                     ".png": "image/png", ".webp": "image/webp",
                 }.get(art_resolved.suffix.lower(), "image/jpeg")
                 return _file_art_response(art_resolved, mt, request)
-        return JSONResponse({"error": "no art"}, 404)
 
-    # Custom art uploaded via /art/upload is cached as PNG under ART_CACHE_DIR;
-    # serve it if present (works for any song the user pinned art to).
-    art_cache = ART_CACHE_DIR
-    safe_name = filename.replace("/", "_").replace(" ", "_")
-    cached = art_cache / f"{safe_name}.png"
-    if cached.exists():
-        return _file_art_response(cached, "image/png", request)
+    # 3. Cover Art Archive cache (the enrichment art worker's fetch).
+    row = meta_db.get_enrichment(filename)
+    if row and row.get("art_state") == "caa" and row.get("art_cache_path"):
+        caa = Path(row["art_cache_path"])
+        if caa.is_file():
+            return _file_art_response(caa, "image/jpeg", request)
 
     return JSONResponse({"error": "no art"}, 404)
 
@@ -10098,9 +10301,43 @@ def update_song_meta(filename: str, data: dict):
     return {"ok": True, "persisted": persisted}
 
 
+def _save_art_override(filename: str, img_data: bytes) -> dict:
+    """Persist a user art override into the art cache (R3). One override per
+    song: GIF input is validated and kept VERBATIM as .gif (animation intact —
+    the local-only bonus; it is never written into the pack file), everything
+    else is normalized to RGB PNG via PIL. Saving either kind removes the
+    other so the serve chain has exactly one user file to find."""
+    ART_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    stem = _art_safe_name(filename)
+    png_path = ART_CACHE_DIR / f"{stem}.png"
+    gif_path = ART_CACHE_DIR / f"{stem}.gif"
+    from PIL import Image
+    import io as _io
+    if img_data[:6] in (b"GIF87a", b"GIF89a"):
+        try:
+            probe = Image.open(_io.BytesIO(img_data))
+            probe.verify()   # decodes headers/frames without keeping the image
+            if probe.format != "GIF":
+                raise ValueError("not a GIF")
+        except Exception as e:
+            return {"error": f"Invalid image: {e}"}
+        gif_path.write_bytes(img_data)
+        png_path.unlink(missing_ok=True)
+        return {"ok": True, "kind": "gif"}
+    try:
+        img = Image.open(_io.BytesIO(img_data)).convert("RGB")
+        img.save(str(png_path), "PNG")
+    except Exception as e:
+        return {"error": f"Invalid image: {e}"}
+    gif_path.unlink(missing_ok=True)
+    return {"ok": True, "kind": "png"}
+
+
 @app.post("/api/song/{filename:path}/art/upload")
 async def upload_song_art_b64(filename: str, data: dict):
-    """Upload custom album art as base64 PNG/JPG."""
+    """Upload a custom cover as base64 (PNG/JPG/WebP → normalized PNG;
+    GIF → kept animated, local-only). The override outranks pack art in the
+    serve chain; remove it via DELETE …/art/override."""
     import base64
     b64 = data.get("image", "")
     if not b64:
@@ -10112,22 +10349,74 @@ async def upload_song_art_b64(filename: str, data: dict):
         img_data = base64.b64decode(b64)
     except Exception:
         return {"error": "Invalid base64"}
+    return _save_art_override(filename, img_data)
 
-    art_cache = ART_CACHE_DIR
-    art_cache.mkdir(parents=True, exist_ok=True)
-    safe_name = filename.replace("/", "_").replace(" ", "_")
-    cached = art_cache / f"{safe_name}.png"
 
-    # Convert to PNG if needed
+# Art-by-URL fetch cap — a cover, not a wallpaper pack.
+_ART_URL_MAX_BYTES = 10 * 1024 * 1024
+
+
+def _fetch_art_url(url: str) -> bytes:
+    """The one place art-by-URL touches the network (tests fake this seam).
+    User-initiated, so not throttled like the background workers — but the
+    same offline guard applies (pytest can never fetch), and the size cap is
+    enforced while streaming so a huge response never fully downloads."""
+    if not _enrich_network_enabled():
+        raise EnrichTransportError("art fetch disabled (offline)")
+    import requests
     try:
-        from PIL import Image
-        import io
-        img = Image.open(io.BytesIO(img_data)).convert("RGB")
-        img.save(str(cached), "PNG")
-    except Exception as e:
-        return {"error": f"Invalid image: {e}"}
+        resp = requests.get(url, timeout=15, stream=True,
+                            headers={"User-Agent": _enrich_user_agent()})
+    except requests.RequestException as e:
+        raise EnrichTransportError(str(e)) from e
+    if resp.status_code != 200:
+        raise EnrichTransportError(f"HTTP {resp.status_code}")
+    data = b""
+    for chunk in resp.iter_content(65536):
+        data += chunk
+        if len(data) > _ART_URL_MAX_BYTES:
+            raise ValueError("image larger than 10 MB")
+    return data
 
-    return {"ok": True}
+
+@app.post("/api/song/{filename:path}/art/url")
+def set_song_art_from_url(filename: str, data: dict):
+    """Paste-a-link cover art (the media-server idiom): the server fetches the
+    image and stores it as this song's local override — identical result to an
+    upload, including the GIF-stays-local rule. http(s) only."""
+    url = str((data or {}).get("url") or "").strip()
+    from urllib.parse import urlparse
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        raise HTTPException(status_code=400, detail="url must be http(s)")
+    dlc = _get_dlc_dir()
+    song_path = _resolve_dlc_path(dlc, filename) if dlc else None
+    if song_path is None or not song_path.exists():
+        raise HTTPException(status_code=404, detail="unknown song")
+    try:
+        img_data = _fetch_art_url(url)
+    except EnrichTransportError as e:
+        return JSONResponse({"error": "could not fetch image", "detail": str(e)},
+                            status_code=502)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return _save_art_override(filename, img_data)
+
+
+@app.delete("/api/art/{filename:path}/override")
+def remove_song_art_override(filename: str):
+    """Drop the user art override — the serve chain falls back to pack art,
+    then the Cover Art Archive cache. Lives under /api/art (NOT /api/song) so
+    the greedy DELETE /api/song/{path} catch-all can't shadow it — the same
+    dodge the chart split/unsplit routes use."""
+    removed = False
+    for p in _art_override_paths(filename):
+        try:
+            p.unlink()
+            removed = True
+        except OSError:
+            pass
+    return {"ok": True, "removed": removed}
 
 
 @app.get("/api/song/{filename:path}")

--- a/static/v3/index.html
+++ b/static/v3/index.html
@@ -742,13 +742,41 @@
                             <div class="fb-srow-desc">Matches your charts against MusicBrainz in the background to tidy names, years and genres — display only, your files are never modified. Matches at or above the confidence level apply automatically; the rest wait in the library's review queue. Turning this off never disables manual match fixes.</div>
                         </div>
                         <div class="grid grid-cols-2 gap-2 mb-1 text-xs text-gray-400 fb-srow-wide">
-                            <label class="flex items-center gap-2"><input type="checkbox" id="enrich-enabled" checked class="rounded border-gray-600 bg-dark-700 text-accent"> Match songs against MusicBrainz</label>
+                            <label class="flex items-center gap-2"><input type="checkbox" id="enrich-enabled" checked class="rounded border-gray-600 bg-dark-700 text-accent"> Match songs automatically</label>
                             <label class="flex items-center gap-2">Auto-apply confidence
                                 <select id="enrich-threshold" class="bg-dark-700 border border-gray-800 rounded-xl px-2 py-1.5 text-xs text-gray-300 outline-none">
                                     <option value="0.85">85% — more auto-matches</option>
                                     <option value="0.9" selected>90% (recommended)</option>
                                     <option value="0.95">95% — cautious</option>
                                     <option value="1.01">Always review</option>
+                                </select>
+                            </label>
+                        </div>
+                        <!-- R1 scraper options: sources (who may be contacted) ×
+                             auto-apply fields (what a confident match fills in). -->
+                        <div class="fb-srow-wide mb-1">
+                            <div class="text-[10px] uppercase tracking-wide text-gray-500 mb-1">Sources</div>
+                            <div class="grid grid-cols-2 gap-2 text-xs text-gray-400">
+                                <label class="flex items-center gap-2"><input type="checkbox" id="enrich-src-musicbrainz" checked class="rounded border-gray-600 bg-dark-700 text-accent"> MusicBrainz — names, years, genres</label>
+                                <label class="flex items-center gap-2"><input type="checkbox" id="enrich-src-caa" checked class="rounded border-gray-600 bg-dark-700 text-accent"> Cover Art Archive — album covers</label>
+                            </div>
+                        </div>
+                        <div class="fb-srow-wide mb-1">
+                            <div class="text-[10px] uppercase tracking-wide text-gray-500 mb-1">Auto-apply</div>
+                            <div class="grid grid-cols-4 gap-2 text-xs text-gray-400">
+                                <label class="flex items-center gap-2"><input type="checkbox" id="enrich-apply-names" checked class="rounded border-gray-600 bg-dark-700 text-accent"> Names</label>
+                                <label class="flex items-center gap-2"><input type="checkbox" id="enrich-apply-year" checked class="rounded border-gray-600 bg-dark-700 text-accent"> Year</label>
+                                <label class="flex items-center gap-2"><input type="checkbox" id="enrich-apply-genres" checked class="rounded border-gray-600 bg-dark-700 text-accent"> Genres</label>
+                                <label class="flex items-center gap-2"><input type="checkbox" id="enrich-apply-art" checked class="rounded border-gray-600 bg-dark-700 text-accent"> Cover art</label>
+                            </div>
+                            <div class="text-[11px] text-gray-600 mt-1">What a confident match may fill in on its own — matches you confirm in the review queue always apply in full.</div>
+                        </div>
+                        <div class="grid grid-cols-2 gap-2 mb-1 text-xs text-gray-400 fb-srow-wide">
+                            <label class="flex items-center gap-2">Review queue order
+                                <select id="enrich-review-order" class="bg-dark-700 border border-gray-800 rounded-xl px-2 py-1.5 text-xs text-gray-300 outline-none">
+                                    <option value="missing_first" selected>Missing info first</option>
+                                    <option value="artist">Artist A–Z</option>
+                                    <option value="recent">Recently added</option>
                                 </select>
                             </label>
                         </div>

--- a/static/v3/match-review.js
+++ b/static/v3/match-review.js
@@ -368,16 +368,28 @@
     // Markup lives statically in index.html (the v3 settings pattern); this
     // wires it. All null-guarded so v2 (which lacks the elements) no-ops.
     function wireSettingsCard() {
-        const toggle = document.getElementById('enrich-enabled');
         const sel = document.getElementById('enrich-threshold');
+        const order = document.getElementById('enrich-review-order');
         const btn = document.getElementById('enrich-match-now');
-        if (!toggle && !sel && !btn) return;
+        // Boolean toggles, element id → settings key. enrich-enabled is the
+        // master background switch; the rest are the R1 scraper options
+        // (per-source + per-field auto-apply).
+        const toggles = [
+            ['enrich-enabled', 'enrich_enabled'],
+            ['enrich-src-musicbrainz', 'enrich_src_musicbrainz'],
+            ['enrich-src-caa', 'enrich_src_caa'],
+            ['enrich-apply-names', 'enrich_apply_names'],
+            ['enrich-apply-year', 'enrich_apply_year'],
+            ['enrich-apply-genres', 'enrich_apply_genres'],
+            ['enrich-apply-art', 'enrich_apply_art'],
+        ].map(([id, key]) => [document.getElementById(id), key]).filter(([el]) => el);
+        if (!toggles.length && !sel && !btn) return;
         (async () => {
             try {
                 const r = await fetch('/api/settings');
                 if (r.ok) {
                     const cfg = await r.json();
-                    if (toggle) toggle.checked = cfg.enrich_enabled !== false;
+                    for (const [el, key] of toggles) el.checked = cfg[key] !== false;
                     if (sel) {
                         const t = Number(cfg.enrich_auto_threshold);
                         const want = Number.isFinite(t) ? t : 0.9;
@@ -388,13 +400,20 @@
                         }
                         if (best) sel.value = best.value;
                     }
+                    if (order) {
+                        const v = String(cfg.enrich_review_order || 'missing_first');
+                        order.value = ['missing_first', 'artist', 'recent'].includes(v) ? v : 'missing_first';
+                    }
                 }
             } catch (_) { /* leave markup defaults */ }
             refreshChip();   // also fills #enrich-status
         })();
         const save = (key, value) => post('/api/settings', { [key]: value });
-        toggle?.addEventListener('change', () => save('enrich_enabled', !!toggle.checked));
+        for (const [el, key] of toggles) {
+            el.addEventListener('change', () => save(key, !!el.checked));
+        }
         sel?.addEventListener('change', () => save('enrich_auto_threshold', Number(sel.value)));
+        order?.addEventListener('change', () => save('enrich_review_order', order.value));
         btn?.addEventListener('click', async () => {
             await post('/api/enrichment/kick');
             const line = document.getElementById('enrich-status');

--- a/tests/test_art_layer.py
+++ b/tests/test_art_layer.py
@@ -1,0 +1,273 @@
+"""Tests for the R3 art layer: the user>pack>CAA serve chain, user overrides
+(upload / URL / delete, with GIF kept animated and LOCAL-ONLY), and the
+enrichment art worker's Cover Art Archive fetch + LRU cache.
+
+Both network seams (`_caa_http_get`, `_fetch_art_url`) are faked — nothing
+here opens a socket, and the offline default is itself asserted.
+"""
+
+import importlib
+import io as _io
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+
+
+@pytest.fixture()
+def server(tmp_path, monkeypatch, isolate_logging):
+    monkeypatch.setenv("CONFIG_DIR", str(tmp_path / "config"))
+    dlc = tmp_path / "dlc"
+    dlc.mkdir()
+    monkeypatch.setenv("DLC_DIR", str(dlc))
+    monkeypatch.setenv("FEEDBACK_SKIP_STARTUP_TASKS", "1")
+    sys.modules.pop("server", None)
+    srv = importlib.import_module("server")
+    try:
+        yield srv
+    finally:
+        conn = getattr(getattr(srv, "meta_db", None), "conn", None)
+        if conn is not None:
+            conn.close()
+        sys.modules.pop("server", None)
+
+
+@pytest.fixture()
+def client(server):
+    return TestClient(server.app)
+
+
+def png_bytes(color=(200, 30, 30)):
+    buf = _io.BytesIO()
+    Image.new("RGB", (4, 4), color).save(buf, "PNG")
+    return buf.getvalue()
+
+
+def gif_bytes():
+    """A tiny 2-frame animated GIF."""
+    buf = _io.BytesIO()
+    frames = [Image.new("P", (4, 4), i) for i in (0, 255)]
+    frames[0].save(buf, "GIF", save_all=True, append_images=frames[1:], duration=100)
+    return buf.getvalue()
+
+
+def make_sloppak(server, name, with_cover=False, title="Song", artist="Artist"):
+    d = server.DLC_DIR / name
+    d.mkdir(parents=True)
+    (d / "manifest.yaml").write_text(
+        f"title: {title}\nartist: {artist}\nduration: 100\n"
+        "arrangements: []\nstems: []\n", encoding="utf-8")
+    if with_cover:
+        (d / "cover.jpg").write_bytes(png_bytes((10, 200, 10)))
+    server.meta_db.put(name, 0, 0, {
+        "title": title, "artist": artist, "album": "", "year": "",
+        "duration": 100, "arrangements": [{"name": "Lead", "index": 0}],
+    })
+    return d
+
+
+def b64(data):
+    import base64
+    return base64.b64encode(data).decode()
+
+
+# ── the serve chain: user > pack > CAA ────────────────────────────────────────
+
+def test_user_override_beats_pack_art(server, client):
+    make_sloppak(server, "a.sloppak", with_cover=True)
+    r = client.get("/api/song/a.sloppak/art")
+    assert r.status_code == 200                       # pack art serves
+    assert client.post("/api/song/a.sloppak/art/upload",
+                       json={"image": b64(png_bytes((1, 2, 3)))}).json()["ok"]
+    r = client.get("/api/song/a.sloppak/art")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "image/png"   # the override, not the pack jpeg
+    # Removing the override falls back to pack art. (The route lives under
+    # /api/art — the DELETE /api/song/{path} catch-all would shadow it.)
+    assert client.delete("/api/art/a.sloppak/override").json()["removed"]
+    r = client.get("/api/song/a.sloppak/art")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "image/jpeg"
+
+
+def test_gif_override_kept_animated_and_local_only(server, client):
+    make_sloppak(server, "a.sloppak", with_cover=True)
+    raw = gif_bytes()
+    body = client.post("/api/song/a.sloppak/art/upload", json={"image": b64(raw)}).json()
+    assert body == {"ok": True, "kind": "gif"}
+    r = client.get("/api/song/a.sloppak/art")
+    assert r.headers["content-type"] == "image/gif"
+    assert r.content == raw                           # VERBATIM — animation intact
+    # …and the pack file was never touched (GIF never reaches the feedpak).
+    assert (server.DLC_DIR / "a.sloppak" / "cover.jpg").read_bytes() == png_bytes((10, 200, 10))
+    assert not (server.DLC_DIR / "a.sloppak" / "cover.gif").exists()
+    # A later PNG upload replaces the GIF (one override per song).
+    client.post("/api/song/a.sloppak/art/upload", json={"image": b64(png_bytes())})
+    assert client.get("/api/song/a.sloppak/art").headers["content-type"] == "image/png"
+    assert len(server._art_override_paths("a.sloppak")) == 1
+
+
+def test_bad_upload_rejected(server, client):
+    make_sloppak(server, "a.sloppak")
+    assert "error" in client.post("/api/song/a.sloppak/art/upload",
+                                  json={"image": b64(b"GIF89a not really a gif")}).json()
+    assert "error" in client.post("/api/song/a.sloppak/art/upload",
+                                  json={"image": b64(b"plain text")}).json()
+
+
+# ── art by URL ────────────────────────────────────────────────────────────────
+
+def test_art_url_fetches_and_overrides(server, client, monkeypatch):
+    make_sloppak(server, "a.sloppak", with_cover=True)
+    monkeypatch.setattr(server, "_fetch_art_url", lambda url: png_bytes((9, 9, 9)))
+    body = client.post("/api/song/a.sloppak/art/url",
+                       json={"url": "https://example.com/cover.png"}).json()
+    assert body == {"ok": True, "kind": "png"}
+    assert client.get("/api/song/a.sloppak/art").headers["content-type"] == "image/png"
+
+
+def test_art_url_validation(server, client, monkeypatch):
+    make_sloppak(server, "a.sloppak")
+    assert client.post("/api/song/a.sloppak/art/url",
+                       json={"url": "ftp://example.com/x.png"}).status_code == 400
+    assert client.post("/api/song/a.sloppak/art/url", json={}).status_code == 400
+    assert client.post("/api/song/ghost.sloppak/art/url",
+                       json={"url": "https://example.com/x.png"}).status_code == 404
+    # Oversize → 400 (the seam raises ValueError at the cap).
+    def _huge(url):
+        raise ValueError("image larger than 10 MB")
+    monkeypatch.setattr(server, "_fetch_art_url", _huge)
+    assert client.post("/api/song/a.sloppak/art/url",
+                       json={"url": "https://example.com/x.png"}).status_code == 400
+
+
+def test_art_url_offline_by_default(server, client):
+    """The real fetch seam refuses under the test env — pytest can never
+    reach the network even when a test forgets to fake it."""
+    make_sloppak(server, "a.sloppak")
+    r = client.post("/api/song/a.sloppak/art/url",
+                    json={"url": "https://example.com/x.png"})
+    assert r.status_code == 502
+
+
+# ── the enrichment art worker (Cover Art Archive) ─────────────────────────────
+
+def _match_row(server, fn, release_id="rel-1"):
+    """Seed a matched enrichment row with a release id (as the P8 matcher
+    would have written) so the art worker picks it up."""
+    song = server.meta_db.enrichment_song_row(fn)
+    h = server.meta_db.enrichment_content_hash(
+        song["artist"], song["title"], song["album"], song["duration"])
+    server.meta_db.apply_enrichment_match(
+        fn, h, "matched", source="text", score=1.0,
+        cand={"recording_id": "rec-1", "release_id": release_id,
+              "title": song["title"], "artist": song["artist"]})
+
+
+@pytest.fixture()
+def caa(server, monkeypatch):
+    """Fake CAA transport + network flag on (mirrors the P8 test fixture)."""
+    calls = []
+    art = {"rel-1": png_bytes((60, 60, 200))}
+
+    def fake(release_id):
+        calls.append(release_id)
+        return art.get(release_id)
+    fake.calls, fake.art = calls, art
+    monkeypatch.setattr(server, "_caa_http_get", fake)
+    monkeypatch.setattr(server, "_enrich_network_enabled", lambda: True)
+    return fake
+
+
+def test_caa_fetch_fills_missing_art(server, client, caa):
+    make_sloppak(server, "a.sloppak")                 # no pack art
+    _match_row(server, "a.sloppak")
+    server._background_enrich()
+    row = server.meta_db.get_enrichment("a.sloppak")
+    assert row["art_state"] == "caa"
+    assert row["art_cache_path"] and row["art_cache_path"].endswith("caa_rel-1.jpg")
+    r = client.get("/api/song/a.sloppak/art")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "image/jpeg"
+    # Settled: the next pass never re-fetches.
+    n = len(caa.calls)
+    server._background_enrich()
+    assert len(caa.calls) == n
+
+
+def test_caa_skips_pack_art_and_dedupes_by_release(server, caa):
+    make_sloppak(server, "haspack.sloppak", with_cover=True, title="One")
+    make_sloppak(server, "b.sloppak", title="Two")
+    make_sloppak(server, "c.sloppak", title="Three")
+    _match_row(server, "haspack.sloppak")
+    _match_row(server, "b.sloppak")                   # same release as c
+    _match_row(server, "c.sloppak")
+    server._background_enrich()
+    assert server.meta_db.get_enrichment("haspack.sloppak")["art_state"] == "pack"
+    assert server.meta_db.get_enrichment("b.sloppak")["art_state"] == "caa"
+    assert server.meta_db.get_enrichment("c.sloppak")["art_state"] == "caa"
+    assert len(caa.calls) == 1                        # one release → ONE fetch
+
+
+def test_caa_404_marks_none(server, caa):
+    make_sloppak(server, "a.sloppak")
+    _match_row(server, "a.sloppak", release_id="rel-missing")
+    server._background_enrich()
+    assert server.meta_db.get_enrichment("a.sloppak")["art_state"] == "none"
+    n = len(caa.calls)
+    server._background_enrich()
+    assert len(caa.calls) == n                        # never re-hammered
+
+
+def test_caa_transport_error_leaves_row_unevaluated(server, caa, monkeypatch):
+    make_sloppak(server, "a.sloppak")
+    _match_row(server, "a.sloppak")
+
+    def _down(release_id):
+        raise server.EnrichTransportError("down")
+    monkeypatch.setattr(server, "_caa_http_get", _down)
+    server._background_enrich()
+    assert server.meta_db.get_enrichment("a.sloppak")["art_state"] is None
+    # Network back → next pass completes it.
+    monkeypatch.setattr(server, "_caa_http_get", caa)
+    server._background_enrich()
+    assert server.meta_db.get_enrichment("a.sloppak")["art_state"] == "caa"
+
+
+def test_offline_default_skips_art_worker(server, monkeypatch):
+    """Under the plain test env the whole art phase is skipped with the rest
+    of the network work."""
+    calls = []
+    monkeypatch.setattr(server, "_caa_http_get", lambda rid: calls.append(rid))
+    make_sloppak(server, "a.sloppak")
+    _match_row(server, "a.sloppak")
+    server._background_enrich()
+    assert calls == []
+    assert server.meta_db.get_enrichment("a.sloppak")["art_state"] is None
+
+
+def test_lru_prune_evicts_oldest_and_resets_rows(server, caa, monkeypatch):
+    monkeypatch.setattr(server, "_CAA_CACHE_CAP_BYTES", 1)   # everything over cap
+    make_sloppak(server, "a.sloppak", title="One")
+    make_sloppak(server, "b.sloppak", title="Two")
+    caa.art["rel-2"] = png_bytes((1, 1, 1))
+    _match_row(server, "a.sloppak", release_id="rel-1")
+    _match_row(server, "b.sloppak", release_id="rel-2")
+    server._background_enrich()
+    # With a 1-byte cap every fetch immediately evicts — the rows that pointed
+    # at evicted files were reset to unevaluated.
+    caa_files = list(server.ART_CACHE_DIR.glob("caa_*.jpg"))
+    assert len(caa_files) <= 1
+    states = {fn: server.meta_db.get_enrichment(fn)["art_state"]
+              for fn in ("a.sloppak", "b.sloppak")}
+    assert None in states.values() or list(states.values()).count("caa") <= 1
+
+
+def test_delete_song_removes_override(server, client):
+    make_sloppak(server, "a.sloppak")
+    client.post("/api/song/a.sloppak/art/upload", json={"image": b64(png_bytes())})
+    assert server._art_override_paths("a.sloppak")
+    r = client.delete("/api/song/a.sloppak")
+    assert r.status_code == 200
+    assert server._art_override_paths("a.sloppak") == []

--- a/tests/test_demo_mode.py
+++ b/tests/test_demo_mode.py
@@ -98,6 +98,9 @@ def test_demo_off_settings_post_not_blocked(tmp_path, monkeypatch):
     ("POST",   "/api/enrichment/review/some-file/pick"),
     ("POST",   "/api/enrichment/kick"),
     ("GET",    "/api/enrichment/search"),
+    # Art layer (R3): the server-side URL fetch + the override delete.
+    ("POST",   "/api/song/some-file/art/url"),
+    ("DELETE", "/api/art/some-file/override"),
 ])
 def test_demo_on_blocked_routes_return_403(tmp_path, monkeypatch, method, path):
     server, client = _make_client(tmp_path, monkeypatch, demo=True)

--- a/tests/test_scraper_options.py
+++ b/tests/test_scraper_options.py
@@ -1,0 +1,284 @@
+"""Tests for the R1 scraper options: per-source toggles (MusicBrainz /
+Cover Art Archive), per-field auto-apply toggles (names / year / genres /
+cover art), and the review-queue order preference.
+
+Same no-network contract as the P8/R3 suites: both transports are faked
+over their single seams (`_mb_http_get`, `_caa_http_get`) and the network
+flag is only force-enabled where a test needs the pipeline to run.
+"""
+
+import importlib
+import io as _io
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+
+
+@pytest.fixture()
+def server(tmp_path, monkeypatch, isolate_logging):
+    monkeypatch.setenv("CONFIG_DIR", str(tmp_path / "config"))
+    dlc = tmp_path / "dlc"
+    dlc.mkdir()
+    monkeypatch.setenv("DLC_DIR", str(dlc))
+    monkeypatch.setenv("FEEDBACK_SKIP_STARTUP_TASKS", "1")
+    sys.modules.pop("server", None)
+    srv = importlib.import_module("server")
+    try:
+        yield srv
+    finally:
+        conn = getattr(getattr(srv, "meta_db", None), "conn", None)
+        if conn is not None:
+            conn.close()
+        sys.modules.pop("server", None)
+
+
+@pytest.fixture()
+def client(server):
+    return TestClient(server.app)
+
+
+class FakeMB:
+    """Canned MusicBrainz over the `_mb_http_get` seam (the P8 fixture)."""
+
+    def __init__(self):
+        self.calls = []
+        self.search_response = {"recordings": []}
+
+    def __call__(self, path, params):
+        self.calls.append((path, dict(params)))
+        if path == "recording":
+            return self.search_response
+        raise AssertionError(f"unexpected MB path {path!r}")
+
+
+@pytest.fixture()
+def mb(server, monkeypatch):
+    fake = FakeMB()
+    monkeypatch.setattr(server, "_mb_http_get", fake)
+    monkeypatch.setattr(server, "_enrich_network_enabled", lambda: True)
+    return fake
+
+
+def _put(server, fn, title="Thunderstruck (v2)", artist="ACDC", album="",
+         duration=292, year="1990", mtime=0):
+    server.meta_db.put(fn, mtime, 0, {
+        "title": title, "artist": artist, "album": album, "year": year,
+        "duration": duration, "arrangements": [{"name": "Lead", "index": 0}],
+    })
+
+
+def mb_doc(rid="rec-1", title="Thunderstruck", artist="AC/DC", artist_id="art-1",
+           album="The Razors Edge", date="1990-09-24", length_ms=292000, score=100):
+    return {
+        "id": rid, "score": score, "title": title, "length": length_ms,
+        "isrcs": ["AUAP09000045"],
+        "artist-credit": [{"name": artist, "artist": {
+            "id": artist_id, "name": artist, "sort-name": artist}}],
+        "releases": [{"id": "rel-1", "title": album, "status": "Official",
+                      "date": date, "release-group": {"primary-type": "Album"}}],
+        "tags": [{"name": "hard rock", "count": 7}],
+    }
+
+
+# ── settings keys ─────────────────────────────────────────────────────────────
+
+BOOL_KEYS = ("enrich_src_musicbrainz", "enrich_src_caa", "enrich_apply_names",
+             "enrich_apply_year", "enrich_apply_genres", "enrich_apply_art")
+
+
+def test_scraper_option_keys_validate_and_persist(client):
+    for key in BOOL_KEYS:
+        bad = client.post("/api/settings", json={key: "yes"}).json()
+        assert "error" in bad
+        client.post("/api/settings", json={key: False})
+        assert client.get("/api/settings").json()[key] is False
+    assert "error" in client.post(
+        "/api/settings", json={"enrich_review_order": "random"}).json()
+    assert "error" in client.post(
+        "/api/settings", json={"enrich_review_order": 42}).json()
+    client.post("/api/settings", json={"enrich_review_order": "artist"})
+    assert client.get("/api/settings").json()["enrich_review_order"] == "artist"
+
+
+def test_defaults_present(server):
+    d = server._default_settings()
+    for key in BOOL_KEYS:
+        assert d[key] is True
+    assert d["enrich_review_order"] == "missing_first"
+
+
+# ── per-source: MusicBrainz ───────────────────────────────────────────────────
+
+def test_musicbrainz_source_off_stamps_without_matching(server, mb, client):
+    client.post("/api/settings", json={"enrich_src_musicbrainz": False})
+    _put(server, "a.sloppak")
+    mb.search_response = {"recordings": [mb_doc()]}
+    server._background_enrich()
+    assert mb.calls == []
+    row = server.meta_db.get_enrichment("a.sloppak")
+    assert row["match_state"] == "unscanned"       # hash stamped, no match
+    # Re-enabling picks the same row up on the next pass.
+    client.post("/api/settings", json={"enrich_src_musicbrainz": True})
+    server._background_enrich()
+    assert server.meta_db.get_enrichment("a.sloppak")["match_state"] == "matched"
+
+
+# ── per-field auto-apply ──────────────────────────────────────────────────────
+
+def test_field_toggles_strip_auto_applied_fields(server, mb, client):
+    client.post("/api/settings", json={"enrich_apply_year": False,
+                                       "enrich_apply_genres": False})
+    _put(server, "a.sloppak")
+    mb.search_response = {"recordings": [mb_doc()]}
+    server._background_enrich()
+    row = server.meta_db.get_enrichment("a.sloppak")
+    assert row["match_state"] == "matched"
+    assert row["canon_artist"] == "AC/DC"
+    assert row["canon_title"] == "Thunderstruck"
+    assert row["canon_album"] == "The Razors Edge"
+    assert row["canon_year"] is None               # toggled off
+    assert row["genres"] == []                     # toggled off
+    # Identity ids always stamp — the art fetch and re-matching need them.
+    assert row["mb_recording_id"] == "rec-1"
+    assert row["mb_release_id"] == "rel-1"
+
+
+def test_names_toggle_keeps_ids_and_other_fields(server, mb, client):
+    client.post("/api/settings", json={"enrich_apply_names": False})
+    _put(server, "a.sloppak")
+    mb.search_response = {"recordings": [mb_doc()]}
+    server._background_enrich()
+    row = server.meta_db.get_enrichment("a.sloppak")
+    assert row["match_state"] == "matched"
+    assert row["canon_artist"] is None
+    assert row["canon_title"] is None
+    assert row["canon_album"] is None
+    assert row["canon_year"] == "1990"
+    assert row["genres"] == ["hard rock"]
+    assert row["mb_recording_id"] == "rec-1"
+
+
+def test_review_accept_applies_all_fields_despite_toggles(server, mb, client):
+    """A match the USER confirms is their intent — the auto-apply toggles
+    gate only what happens without them."""
+    client.post("/api/settings", json={"enrich_apply_names": False,
+                                       "enrich_apply_year": False,
+                                       "enrich_apply_genres": False})
+    # Partial artist agreement → review tier (candidates stored unfiltered).
+    _put(server, "a.sloppak", artist="AC/DC ft Nobody")
+    mb.search_response = {"recordings": [mb_doc()]}
+    server._background_enrich()
+    assert server.meta_db.get_enrichment("a.sloppak")["match_state"] == "review"
+    r = client.post("/api/enrichment/review/a.sloppak/accept",
+                    json={"recording_id": "rec-1"})
+    assert r.status_code == 200
+    row = server.meta_db.get_enrichment("a.sloppak")
+    assert row["match_state"] == "manual"
+    assert row["canon_artist"] == "AC/DC"
+    assert row["canon_year"] == "1990"
+    assert row["genres"] == ["hard rock"]
+
+
+# ── per-source / per-field: cover art ─────────────────────────────────────────
+
+def png_bytes(color=(200, 30, 30)):
+    buf = _io.BytesIO()
+    Image.new("RGB", (4, 4), color).save(buf, "PNG")
+    return buf.getvalue()
+
+
+def make_sloppak(server, name, title="Song", artist="Artist"):
+    d = server.DLC_DIR / name
+    d.mkdir(parents=True)
+    (d / "manifest.yaml").write_text(
+        f"title: {title}\nartist: {artist}\nduration: 100\n"
+        "arrangements: []\nstems: []\n", encoding="utf-8")
+    server.meta_db.put(name, 0, 0, {
+        "title": title, "artist": artist, "album": "", "year": "",
+        "duration": 100, "arrangements": [{"name": "Lead", "index": 0}],
+    })
+    return d
+
+
+def _match_row(server, fn, release_id="rel-1"):
+    song = server.meta_db.enrichment_song_row(fn)
+    h = server.meta_db.enrichment_content_hash(
+        song["artist"], song["title"], song["album"], song["duration"])
+    server.meta_db.apply_enrichment_match(
+        fn, h, "matched", source="text", score=1.0,
+        cand={"recording_id": "rec-1", "release_id": release_id,
+              "title": song["title"], "artist": song["artist"]})
+
+
+@pytest.fixture()
+def caa(server, monkeypatch):
+    calls = []
+    art = {"rel-1": png_bytes((60, 60, 200))}
+
+    def fake(release_id):
+        calls.append(release_id)
+        return art.get(release_id)
+    fake.calls = calls
+    monkeypatch.setattr(server, "_caa_http_get", fake)
+    monkeypatch.setattr(server, "_enrich_network_enabled", lambda: True)
+    return fake
+
+
+def test_caa_source_toggle_gates_art_fetch(server, client, caa):
+    make_sloppak(server, "a.sloppak")
+    _match_row(server, "a.sloppak")
+    client.post("/api/settings", json={"enrich_src_caa": False})
+    server._background_enrich()
+    assert caa.calls == []
+    row = server.meta_db.get_enrichment("a.sloppak")
+    assert row["art_state"] is None                # not forfeited, just skipped
+    # Re-enable → the same row is picked up.
+    client.post("/api/settings", json={"enrich_src_caa": True})
+    server._background_enrich()
+    assert server.meta_db.get_enrichment("a.sloppak")["art_state"] == "caa"
+
+
+def test_apply_art_toggle_gates_art_fetch(server, client, caa):
+    make_sloppak(server, "a.sloppak")
+    _match_row(server, "a.sloppak")
+    client.post("/api/settings", json={"enrich_apply_art": False})
+    server._background_enrich()
+    assert caa.calls == []
+    assert server.meta_db.get_enrichment("a.sloppak")["art_state"] is None
+
+
+# ── review-queue order ────────────────────────────────────────────────────────
+
+def _review_row(server, fn):
+    server.meta_db.apply_enrichment_match(
+        fn, "h", "review", source="text", score=0.7,
+        candidates=[{"recording_id": "rec-1", "title": "T", "artist": "A"}])
+
+
+def _review_filenames(client):
+    return [s["filename"] for s in
+            client.get("/api/enrichment/review").json()["songs"]]
+
+
+def test_review_queue_order_setting(server, client):
+    # a: complete, artist Alpha, oldest; b: missing album+year, artist Zeta,
+    # middle; c: missing year, artist Mid, newest — the three orders differ.
+    _put(server, "a.sloppak", title="Song A", artist="Alpha",
+         album="Full", year="1990", mtime=100)
+    _put(server, "b.sloppak", title="Song B", artist="Zeta",
+         album="", year="", mtime=200)
+    _put(server, "c.sloppak", title="Song C", artist="Mid",
+         album="Full", year="", mtime=300)
+    for fn in ("a.sloppak", "b.sloppak", "c.sloppak"):
+        _review_row(server, fn)
+
+    # Default: missing-data-first.
+    assert _review_filenames(client) == ["b.sloppak", "c.sloppak", "a.sloppak"]
+    client.post("/api/settings", json={"enrich_review_order": "artist"})
+    assert _review_filenames(client) == ["a.sloppak", "c.sloppak", "b.sloppak"]
+    client.post("/api/settings", json={"enrich_review_order": "recent"})
+    assert _review_filenames(client) == ["c.sloppak", "b.sloppak", "a.sloppak"]
+    # An unknown stored value degrades to the default order, never an error.
+    assert server.meta_db.enrichment_review_queue(order="bogus")[0]["filename"] == "b.sloppak"

--- a/tests/test_scraper_options.py
+++ b/tests/test_scraper_options.py
@@ -181,6 +181,55 @@ def test_review_accept_applies_all_fields_despite_toggles(server, mb, client):
     assert row["genres"] == ["hard rock"]
 
 
+# ── per-field: nothing-forfeited (re-enable backfills, no partial seeding) ─────
+
+def test_reenabling_field_backfills_matched_row(server, mb, client):
+    """A field toggled OFF strips the value AND records it in apply_mask, so
+    turning the field back on re-queues the (unchanged-hash) matched row and
+    backfills — the same "nothing forfeited" contract the source/art toggles
+    keep."""
+    client.post("/api/settings", json={"enrich_apply_year": False})
+    _put(server, "a.sloppak")
+    mb.search_response = {"recordings": [mb_doc()]}
+    server._background_enrich()
+    row = server.meta_db.get_enrichment("a.sloppak")
+    assert row["match_state"] == "matched"
+    assert row["canon_year"] is None                    # suppressed
+    assert row["apply_mask"] == "enrich_apply_year"     # …and remembered
+    # Re-enable → next pass re-queues and backfills the year (hash unchanged).
+    client.post("/api/settings", json={"enrich_apply_year": True})
+    server._background_enrich()
+    row = server.meta_db.get_enrichment("a.sloppak")
+    assert row["match_state"] == "matched"
+    assert row["canon_year"] == "1990"                  # backfilled
+    assert row["apply_mask"] in (None, "")              # fully applied now
+    # Converged: a fully-applied row is not re-queued again.
+    assert server.meta_db.enrichment_pending(
+        allowed_keys=frozenset(server._ENRICH_APPLY_FIELDS)) == []
+
+
+def test_partial_match_is_not_a_cache_donor(server):
+    """A row that suppressed a display field must not seed a sibling chart of
+    the same recording with its blank — enrichment_cache_lookup skips it, so
+    the sibling falls through to its own (correctly-filtered) match. A fully-
+    applied row IS a donor."""
+    h = server.meta_db.enrichment_content_hash("ACDC", "Thunderstruck (v2)", "", 292)
+    # Partial donor: matched with the year suppressed (apply_mask set).
+    server.meta_db.apply_enrichment_match(
+        "a.sloppak", h, "matched", source="text", score=1.0,
+        cand={"recording_id": "rec-1", "artist": "AC/DC", "title": "Thunderstruck"},
+        apply_mask="enrich_apply_year")
+    assert server.meta_db.enrichment_cache_lookup(
+        h, exclude_filename="b.sloppak") is None
+    # Fully-applied donor (no apply_mask): offered, with its year intact.
+    server.meta_db.apply_enrichment_match(
+        "c.sloppak", h, "matched", source="text", score=1.0,
+        cand={"recording_id": "rec-1", "artist": "AC/DC",
+              "title": "Thunderstruck", "year": "1990"})
+    donor = server.meta_db.enrichment_cache_lookup(h, exclude_filename="b.sloppak")
+    assert donor is not None and donor["year"] == "1990"
+
+
 # ── per-source / per-field: cover art ─────────────────────────────────────────
 
 def png_bytes(color=(200, 30, 30)):


### PR DESCRIPTION
## What

The full scraper-options panel (R1 of the round-2 library-metadata batch), grown out of the Settings → Library "Metadata matching" card that shipped with #710. Not everybody needs the same things out of a scraper — this makes each piece opt-out:

**Sources — who may be contacted**
- `enrich_src_musicbrainz` — gates the background matcher (phase 2). Identity hashes still stamp each pass, and manual Fix-match / "Search instead…" in the review modal keep working, exactly like the existing master toggle's contract.
- `enrich_src_caa` — gates the Cover Art Archive fetch (phase 3). Rows skipped while a toggle is off stay unevaluated (`art_state` NULL / `unscanned`), so re-enabling picks them up on the next pass — nothing is permanently forfeited.

**Auto-apply — what a confident match may fill in on its own**
- `enrich_apply_names` / `enrich_apply_year` / `enrich_apply_genres` filter what an **automatic** match canonicalizes, on all three automatic paths (content-hash cache copy, manifest mbid/isrc exact keys, text auto tier). MusicBrainz ids always stamp — they're identity, not display; the art fetch and future re-matching need them.
- A match the user **confirms in the review modal applies in full** — the toggles gate only what happens without them.
- `enrich_apply_art` gates the art fetch together with the CAA source toggle. Two axes for one behaviour today, deliberately: a future second art source slots in without re-teaching the panel.

**Review queue**
- `enrich_review_order` = `missing_first` (default — today's behaviour) | `artist` | `recent`, consumed by `GET /api/enrichment/review`. Unknown stored values degrade to the default.

**UI** — the card gains Sources / Auto-apply / Review-queue-order groups (wired in `match-review.js`); the master toggle is relabelled "Match songs automatically" so it doesn't read the same as the new MusicBrainz source checkbox. No tailwind rebuild needed — every utility used was already in the scanned set.

## Stacking

Based on `feat/enrichment-art` (#715) — the art toggles gate that PR's CAA worker. **Merge #715 first**, then this lands clean.

## Verification

- `tests/test_scraper_options.py` (9 new): settings validation; MB-source-off stamps hashes but never calls the (fake) transport, and re-enabling matches the same row; per-field stripping on auto matches with ids preserved; review-accept applies all fields despite toggles; CAA gating on both axes; all three review-order modes plus the unknown-value fallback.
- All enrichment suites green (77 tests across P7/P8/R3/R1 + pure matcher).
- Full-suite failure set is **byte-identical** with the change stashed vs applied (39 known env/pre-existing failures) — A/B proven.
- `node --check` clean; no new tailwind classes (verified against the built stylesheet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm7tHs1Yvjjtnnu4nzJgdN