### PR TITLE
ci: adapt workflows to trunk-based development

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,9 @@
 name: Nightly
 
+# Trunk-based: nightly always builds main — the release-branch discovery
+# from the old release-centric flow is gone (it pinned nightlies to the
+# highest release/v* branch forever, even after it shipped). Stabilization
+# builds from release/** come from rc.yml instead.
 on:
   schedule:
     - cron: '0 2 * * *'
@@ -9,33 +13,7 @@ permissions:
   contents: read
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    outputs:
-      branch: ${{ steps.branch.outputs.branch }}
-      date: ${{ steps.date.outputs.date }}
-
-    steps:
-      - name: Find active release branch
-        id: branch
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          branch=$(gh api "repos/${{ github.repository }}/git/matching-refs/heads/release/v" \
-            --jq '[.[].ref | ltrimstr("refs/heads/")] | map(ltrimstr("refs/heads/")) | .[]' \
-            | sort -V | tail -1 || true)
-          if [[ -z "$branch" ]]; then
-            branch="main"
-          fi
-          echo "branch=$branch" >> "$GITHUB_OUTPUT"
-          echo "Active branch: $branch"
-
-      - name: Get date
-        id: date
-        run: echo "date=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
-
   build-docker:
-    needs: setup
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -44,8 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.setup.outputs.branch }}
           persist-credentials: false
+
+      - name: Get date
+        id: date
+        run: echo "date=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -65,6 +46,6 @@ jobs:
           push: true
           tags: |
             ghcr.io/got-feedback/feedback:nightly
-            ghcr.io/got-feedback/feedback:nightly-${{ needs.setup.outputs.date }}
+            ghcr.io/got-feedback/feedback:nightly-${{ steps.date.outputs.date }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -1,0 +1,63 @@
+name: rc
+
+# Release-candidate images for stabilization: every push to a release/**
+# branch builds and pushes ghcr.io tags :rc (moving) and
+# :rc-<version>-<date> (pinned). Final versioned images still come from
+# release.yml on tag push.
+on:
+  push:
+    branches: ['release/**']
+
+permissions:
+  contents: read
+
+# One build per branch at a time; a newer push supersedes an in-flight one.
+concurrency:
+  group: rc-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Derive RC tags
+        id: meta
+        run: |
+          # release/v0.3.0 -> 0.3.0 (tolerate a missing v prefix too)
+          version="${GITHUB_REF_NAME#release/}"
+          version="${version#v}"
+          date="$(date -u +%Y%m%d)"
+          {
+            echo "tags<<TAGS_EOF"
+            echo "ghcr.io/got-feedback/feedback:rc"
+            echo "ghcr.io/got-feedback/feedback:rc-${version}-${date}"
+            echo "TAGS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ship-ci.yml
+++ b/.github/workflows/ship-ci.yml
@@ -8,6 +8,11 @@ name: ship-ci
 on:
   pull_request:
     branches: [main, 'release/**']
+  # Trunk-based: post-merge CI on main catches semantic conflicts between
+  # independently-green PRs; push on release/** covers stabilization
+  # cherry-picks that land without a PR.
+  push:
+    branches: [main, 'release/**']
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- **nightly.yml**: build main directly — removed the release/v* branch discovery, which pinned nightlies to the highest release branch forever (even after it shipped)
- **ship-ci.yml**: added `push` triggers on `main` and `release/**` for post-merge CI signal (catches semantic conflicts between independently-green PRs; covers stabilization cherry-picks landing without a PR)
- **rc.yml** (new): every push to `release/**` builds and pushes `ghcr.io/got-feedback/feedback:rc` + `:rc-<version>-<date>` for stabilization testing. Per-branch concurrency, newer push cancels in-flight build.

Unchanged: ci.yml jobs, release.yml (tag-driven, branch-agnostic), sync-version.yml.

Note: sync-version bot commits to main now also trigger a CI run — cheap, extra signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)