### PR TITLE
fix(release): lowercase ghcr repo in image tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,9 +35,9 @@ jobs:
           # stable releases (no pre-release suffix).
           {
             echo "tags<<TAGS_EOF"
-            echo "ghcr.io/${GITHUB_REPOSITORY}:${version}"
+            echo "ghcr.io/${GITHUB_REPOSITORY,,}:${version}"
             if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "ghcr.io/${GITHUB_REPOSITORY}:latest"
+              echo "ghcr.io/${GITHUB_REPOSITORY,,}:latest"
             fi
             echo "TAGS_EOF"
           } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
`release.yml` used `${GITHUB_REPOSITORY}` = `got-feedback/feedBack` (capital B post-rename) → Docker rejected the tag ('repository name must be lowercase'). Lowercase it. Fixes the v0.3.0-alpha.1 core image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)