### PR TITLE
fix(library): serve art/load for songs mounted through a library junction

### DIFF
--- a/lib/safepath.py
+++ b/lib/safepath.py
@@ -26,6 +26,13 @@ def safe_join(root: Path, name: str) -> Path | None:
     """
     if not name:
         return None
+    # Reject embedded NULs explicitly. This used to ride on `.resolve()`
+    # raising ValueError, but on Python 3.13 (Windows) resolve() no longer
+    # raises for an embedded NUL, so the byte would otherwise leak through
+    # containment. An explicit guard is strictly-more-rejection (no effect on
+    # the zip-slip / traversal contract).
+    if "\x00" in name:
+        return None
     safe = name.replace("\\", "/")
     try:
         root_resolved = root.resolve()

--- a/server.py
+++ b/server.py
@@ -5253,6 +5253,16 @@ def _resolve_dlc_path(dlc: Path, filename: str) -> Path | None:
     safe = filename.replace("\\", "/")
     if "\x00" in safe:
         return None
+    # Reject drive-letter / absolute paths in BOTH conventions. A POSIX "/x" is
+    # caught by the containment check below (the `/` operator discards `root`),
+    # but a Windows drive-absolute "C:/x" is treated as a relative "C:" dir on
+    # POSIX and would otherwise slip in as `<root>/C:/x` — so the contract must
+    # hold cross-platform (a shared library is reached from either OS).
+    from pathlib import PurePosixPath, PureWindowsPath
+    if (PurePosixPath(safe).is_absolute()
+            or PureWindowsPath(safe).is_absolute()
+            or PureWindowsPath(safe).drive):
+        return None
     try:
         root = dlc.resolve()
         # normpath collapses `.`/`..`/duplicate separators purely lexically —

--- a/server.py
+++ b/server.py
@@ -5229,10 +5229,42 @@ def _resolve_dlc_path(dlc: Path, filename: str) -> Path | None:
     check so every filename-bound handler validates before touching the
     filesystem.
 
-    Returns the validated resolved Path, or None if the path is empty
-    or escapes the DLC root.
+    Containment here is LEXICAL (normalize `.`/`..` WITHOUT following
+    symlinks), not `safe_join`'s `.resolve()`-based check — because users
+    commonly mount their song library through a directory JUNCTION/symlink
+    (a library shared across app installs; the desktop app's own mounts).
+    `.resolve()` follows that junction to its real target, sees it sits
+    outside DLC_DIR, and wrongly rejects every song reached through it — the
+    scanner's `rglob` indexes those songs, but art/load then 403/404s (broken
+    covers, unplayable songs). Lexical normalization still rejects the only
+    escapes a `:path` filename can express — `..` traversal and absolute
+    paths — which the traversal tests pin. `safe_join` stays strict (it is
+    the zip-slip / plugin-asset guard, where following a symlink out IS the
+    defense); the loose-folder art handler keeps its own per-file symlink
+    re-check for defence-in-depth.
+
+    Returns the validated Path (not necessarily link-resolved), or None if
+    the filename is empty, contains a NUL, or escapes the DLC root.
     """
-    return safe_join(dlc, filename)
+    if not filename:
+        return None
+    # Backslashes → forward slashes so a Windows-style `..\\x` traversal is
+    # rejected identically on POSIX (mirrors safe_join's normalisation).
+    safe = filename.replace("\\", "/")
+    if "\x00" in safe:
+        return None
+    try:
+        root = dlc.resolve()
+        # normpath collapses `.`/`..`/duplicate separators purely lexically —
+        # it never touches the filesystem, so an in-library junction component
+        # is preserved (allowed) while `..`/absolute segments still escape and
+        # get caught by the containment check below.
+        candidate = Path(os.path.normpath(root / safe))
+        if not candidate.is_relative_to(root):
+            return None
+    except (ValueError, OSError):
+        return None
+    return candidate
 
 
 _SMART_TYPE_BASE: dict[str, int] = {"Lead": 0, "Rhythm": 10, "Bass": 20}

--- a/tests/test_dlc_junction.py
+++ b/tests/test_dlc_junction.py
@@ -1,0 +1,92 @@
+"""Unit tests for ``server._resolve_dlc_path`` — the DLC-library containment
+guard.
+
+It must (1) allow a library mounted through a directory JUNCTION/symlink (the
+shared-library-across-installs / desktop-app case that a ``.resolve()``-based
+check wrongly rejected, breaking album art + song load), while (2) still
+rejecting ``..`` traversal and absolute paths — the only escapes a ``:path``
+filename can express. ``safe_join`` stays strict on purpose (zip-slip guard),
+so the contrast is pinned here too.
+"""
+
+import importlib
+import os
+import sys
+
+import pytest
+
+
+@pytest.fixture()
+def server(tmp_path, monkeypatch):
+    (tmp_path / "cfg").mkdir()
+    monkeypatch.setenv("CONFIG_DIR", str(tmp_path / "cfg"))
+    monkeypatch.setenv("FEEDBACK_SKIP_STARTUP_TASKS", "1")
+    sys.modules.pop("server", None)
+    srv = importlib.import_module("server")
+    try:
+        yield srv
+    finally:
+        conn = getattr(getattr(srv, "meta_db", None), "conn", None)
+        if conn is not None:
+            getattr(sys.modules.get("server"), "_join_background_db_threads", lambda: None)()
+            conn.close()
+        sys.modules.pop("server", None)
+
+
+def _dlc(tmp_path):
+    d = tmp_path / "dlc"
+    d.mkdir()
+    return d
+
+
+# ── still-rejected escapes (the security contract) ────────────────────────────
+
+def test_dotdot_traversal_rejected(server, tmp_path):
+    dlc = _dlc(tmp_path)
+    assert server._resolve_dlc_path(dlc, "../../etc/passwd") is None
+    # a Windows-style backslash traversal is normalised + rejected identically
+    assert server._resolve_dlc_path(dlc, "..\\..\\secret") is None
+    assert server._resolve_dlc_path(dlc, "a/../../b") is None
+
+
+def test_absolute_path_rejected(server, tmp_path):
+    dlc = _dlc(tmp_path)
+    assert server._resolve_dlc_path(dlc, "/etc/passwd") is None
+    assert server._resolve_dlc_path(dlc, "C:/Windows/system32/x") is None
+
+
+def test_empty_and_nul_rejected(server, tmp_path):
+    dlc = _dlc(tmp_path)
+    assert server._resolve_dlc_path(dlc, "") is None
+    assert server._resolve_dlc_path(dlc, "a\x00b") is None
+
+
+# ── allowed: legitimate in-library paths ──────────────────────────────────────
+
+def test_safe_relative_allowed(server, tmp_path):
+    dlc = _dlc(tmp_path)
+    p = server._resolve_dlc_path(dlc, "CDLC/City Pop/song.feedpak")
+    assert p is not None
+    assert p.is_relative_to(dlc.resolve())
+
+
+def test_junction_subfolder_allowed(server, tmp_path):
+    """A library mounted through a directory junction/symlink must resolve —
+    the case that broke album art for Christian's shared city-pop library."""
+    dlc = _dlc(tmp_path)
+    real = tmp_path / "real_library"
+    real.mkdir()
+    (real / "song.feedpak").write_bytes(b"pack")
+    link = dlc / "CDLC"
+    try:
+        os.symlink(real, link, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlink/junction creation not permitted on this host")
+
+    p = server._resolve_dlc_path(dlc, "CDLC/song.feedpak")
+    assert p is not None, "a junctioned library subfolder was wrongly rejected"
+    assert p.exists(), "the resolved path should reach the file through the junction"
+    # Contrast: safe_join stays strict (it .resolve()s and follows the junction
+    # to its real target outside the root), which is correct for its zip-slip
+    # callers but is exactly why _resolve_dlc_path can't reuse it here.
+    assert server.safe_join(dlc, "CDLC/song.feedpak") is None


### PR DESCRIPTION
## Symptom
Album art shows as **broken images** (and songs won't load) for any part of the library mounted through a directory **junction / symlink** — e.g. a library shared across app installs, or the desktop app's own mounts.

## Cause
The scanner (`dlc.rglob`) follows a junction and indexes the songs, so the grid shows them. But every path-validated handler goes through `_resolve_dlc_path` → `safe_join`, which does `(root / name).resolve()` and rejects anything whose **resolved** path leaves `DLC_DIR`. A junction resolves to its real target *outside* `DLC_DIR`, so every song reached through it is rejected → **403 `/art`**, **404 `/art/candidates`**, broken covers; `/load` breaks the same way.

## Fix
- **`_resolve_dlc_path`** now uses **lexical containment** (`os.path.normpath`, no symlink following), so an in-library junction is allowed while `..` traversal and absolute paths are still rejected. The traversal contract (`../` → 403, safe-but-missing → 404) is unchanged and pinned by the existing tests.
- **`safe_join` stays strict** (`.resolve()`-based) — it's the **zip-slip / plugin-asset / avatar** guard, where following a symlink *out* is the desired defense, so it is deliberately **not** loosened. It does gain an explicit **NUL guard**: on Python 3.13 (Windows) `resolve()` no longer raises `ValueError` on an embedded NUL, so the byte was leaking through containment; the guard is strictly-more-rejection with no effect on the zip-slip contract (fixes a pre-existing red test on 3.13/Windows).

## Security
Network-facing traversal (`..`, absolute, NUL, URL-encoded) stays fully blocked (unit + endpoint tests). The only new capability is *following a symlink that already lives inside the user's own library* — which requires local write access to plant (and all write routes are demo-blocked in hosted mode), while the loose-folder art handler keeps its own per-file `relative_to(song_path)` symlink re-check. Manual review done; the higher-risk callers retain strict `safe_join`.

## Tests
`tests/test_dlc_junction.py`: junction subfolder allowed (+ resolves through to the file); `..`/absolute/NUL rejected; and a contrast assertion that `safe_join` still rejects the junction (stays strict). Existing `test_loose_traversal` / `test_safepath` / `test_art_candidates` stay green.

Verified live: junctioned city-pop packs that returned 403/404 now serve their real embedded JPEG covers (`/art` → 200 `image/jpeg`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path handling to more reliably reject unsafe inputs, including embedded NUL bytes, empty paths, absolute paths, and directory-traversal attempts.
  * Strengthened DLC path containment checks to ensure requested content stays within the expected DLC root, using stricter normalization rules.
  * Preserved access to valid in-DLC content even when reached through trusted library junctions/symlinks.
* **Tests**
  * Added coverage for DLC junction and path-containment edge cases, including Windows path variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->