### PR TITLE
feat(v3 library): Match→Details "use these values" bridge

### DIFF
--- a/static/v3/match-review.js
+++ b/static/v3/match-review.js
@@ -303,6 +303,7 @@
             '<span class="text-xs text-fb-textDim shrink-0">' + esc(pct) + '</span></span>' +
             '<span class="block text-xs text-fb-textDim truncate">' + esc(meta) + '</span>' +
             diffChips(song, c) +
+            (_single ? '<span class="block text-xs text-fb-primary pt-1">Use these values →</span>' : '') +
             '</button>';
     }
 
@@ -483,7 +484,39 @@
             };
         }
         song._detailsState = st;
+        // Match→Details bridge: a candidate picked with "Use these values" lands
+        // its fields here as the pending (unsaved) input values, shown pre-filled
+        // for review — the grid never adopts a match silently, so the user still
+        // Saves (or Writes to file).
+        const adopted = song._pendingDetails;
+        if (adopted) {
+            for (const [f] of DETAIL_FIELDS) {
+                if (f in adopted) st[f].value = String(adopted[f] || '');
+            }
+            song._pendingDetails = null;
+        }
         paintDetails(body, song);
+        if (adopted) {
+            const s = body.querySelector('[data-df-status]');
+            if (s) { s.className = 'text-xs leading-relaxed text-fb-textDim'; s.textContent = 'Filled from the match — review, then Save or Write to file.'; }
+        }
+    }
+
+    // Match→Details bridge: adopt a candidate's display fields into the Details
+    // tab (opt-in — never silent). Pin the match too so the art/canon follow,
+    // then land on Details pre-filled for review.
+    async function useTheseValues(song, cand) {
+        if (!cand) return;
+        song._pendingDetails = {
+            title: String(cand.title || ''), artist: String(cand.artist || ''),
+            album: String(cand.album || ''), year: String(cand.year || ''),
+        };
+        try {
+            await post('/api/enrichment/review/' + enc(song.filename) + '/pick', { candidate: cand });
+        } catch (_) { /* pin is best-effort; the values still populate Details */ }
+        try { window.feedBack?.emit('library:changed', { reason: 'match' }); } catch (_) { }
+        _tab = 'details';
+        renderTabbed();
     }
 
     function paintDetails(body, song) {
@@ -705,6 +738,7 @@
             btn.addEventListener('click', async () => {
                 const cand = cands[Number(btn.getAttribute('data-mr-cand'))];
                 if (!cand) return;
+                if (_single) { useTheseValues(song, cand); return; }   // popup → adopt into Details
                 await post('/api/enrichment/review/' + enc(song.filename) + '/pick',
                     { candidate: cand });
                 settle(song);
@@ -757,6 +791,7 @@
             btn.addEventListener('click', async () => {
                 const cand = cands[Number(btn.getAttribute('data-mr-cand'))];
                 if (!cand) return;
+                if (_single) { useTheseValues(song, cand); return; }   // popup → adopt into Details
                 await post('/api/enrichment/review/' + enc(song.filename) + '/pick',
                     { candidate: cand });
                 settle(song);


### PR DESCRIPTION
Connects the Fix-metadata popup's two tabs (stacked on #778 → #777).

**The gap:** the **Match** tab finds the correct recording (MusicBrainz search or Identify-by-audio), but by design a match only improves the *underlying* canon + art — it never silently re-titles the grid ("author-set shows by default"). So to actually *display* the match's values you had to retype them into **Details** by hand.

**The bridge:** each Match candidate now shows a **"Use these values →"** action. Clicking it:
- copies the candidate's **title / artist / album / year** into the Details tab as **pending, unsaved** inputs (shown pre-filled with a "review, then Save or Write to file" nudge),
- **pins the match** too (so the art/canon follow),
- and drops you on **Details** to review.

You stay in control — the values are populated for review, not force-saved, so you can tweak (e.g. prefer romaji over kanji) before **Save** (overlay) or **Write to file** (#778). The "never silently adopt a match" rule is intact; this is just the explicit one-click path to opt in.

Queue-review candidates are untouched — they still accept/pin on click.

### Testing
- `node --check` clean; live on the testbed. Verified the served bundle wires `useTheseValues` at both candidate sites (search + Identify).

Stacks on **#778** (Write to file) → **#777** (popup). Merge bottom-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single-song match selection now fills the Details tab instead of immediately finalizing the choice, giving you a chance to review and edit values first.
  * The interface now switches to the Details tab after a candidate is selected and shows a status message confirming the fields were populated.

* **User Experience**
  * Candidate rows now include a clearer hint indicating the selected values will be used in the Details form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->