### PR TITLE
fix(settings): don't let a stale DLC path block saving the Demucs server address

### DIFF
--- a/server.py
+++ b/server.py
@@ -10765,6 +10765,9 @@ def save_settings(data: dict):
     config_file = CONFIG_DIR / "config.json"
     updates: dict = {}
     messages: list[str] = []
+    # Named dlc_warnings (not `warnings`) so it can't shadow the module-level
+    # `import warnings` used elsewhere in this file.
+    dlc_warnings: list[str] = []
 
     if "dlc_dir" in data:
         dlc_path = data["dlc_dir"]
@@ -10784,7 +10787,16 @@ def save_settings(data: dict):
                             if f.suffix.lower() in sloppak_mod.SONG_EXTS)
                 messages.append(f"DLC folder: {count} song files found")
             else:
-                return {"error": f"DLC directory not found: {dlc_path}"}
+                # A non-resolving DLC path (a stale value, an unplugged
+                # external/network drive, or a path carried over from another
+                # machine) must NOT abort the whole POST. saveSettings() bundles
+                # dlc_dir together with demucs_server_url / default_arrangement /
+                # av_offset_ms in a single request, so an early `return` here
+                # silently dropped every co-submitted key — this is the "can't
+                # set the Demucs server address" report (feedBack-demucs-server
+                # #3). Record it as a warning, skip persisting dlc_dir, and keep
+                # validating the rest so the other settings still save.
+                dlc_warnings.append(f"DLC directory not found: {dlc_path}")
 
     # Both of these are consumed downstream as strings (e.g.
     # demucs_server_url.rstrip('/')), so reject non-string shapes
@@ -11041,7 +11053,15 @@ def save_settings(data: dict):
                 return {"error": str(exc)}
             cfg = settings_with_instrument_profiles(cfg)
         _atomic_write_file(config_file, json.dumps(cfg, indent=2).encode("utf-8"))
-    return {"message": ". ".join(messages) if messages else "Settings saved"}
+    resp = {"message": ". ".join(messages) if messages else "Settings saved"}
+    if dlc_warnings:
+        # `warnings` is an additive response field (existing clients read
+        # `message || error`); fold the text into `message` too so the current
+        # settings status line still surfaces the bad DLC path even though the
+        # rest of the save succeeded.
+        resp["warnings"] = dlc_warnings
+        resp["message"] = resp["message"] + " — " + "; ".join(dlc_warnings)
+    return resp
 
 
 # Keys a client "Reset {category}" action may clear. Resetting removes the key

--- a/static/v3/index.html
+++ b/static/v3/index.html
@@ -641,7 +641,12 @@
                             </div>
                         </div>
                         <div class="fb-srow-control">
+                            <!-- Autosave on blur/enter via a single-key POST (like every other v3
+                                 setting), so setting the address never depends on the shared Save
+                                 button — whose bundled dlc_dir could otherwise block it. Save button
+                                 kept for discoverability. -->
                             <input type="text" id="demucs-server-url" placeholder="http://192.168.1.100:7865"
+                                onchange="persistSetting('demucs_server_url', this.value.trim())"
                                 class="bg-dark-700 border border-gray-800 rounded-xl px-4 py-2.5 text-sm text-gray-300 placeholder-gray-600 focus:border-accent/50 outline-none">
                             <button onclick="saveSettings()" class="bg-accent hover:bg-accent-light px-6 py-2.5 rounded-xl text-sm font-semibold text-white transition">Save</button>
                         </div>

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -219,6 +219,47 @@ def test_dlc_dir_empty_string_clears(client, tmp_path):
     assert _read_cfg(tmp_path)["dlc_dir"] == ""
 
 
+def test_unresolvable_dlc_dir_does_not_block_other_keys(client, tmp_path):
+    # Regression (feedBack-demucs-server#3): the v3 "Save" button next to the
+    # Demucs field bundles dlc_dir with demucs_server_url in one POST. A DLC
+    # path that doesn't resolve on THIS machine (stale value / unplugged drive)
+    # must not abort the whole request — the co-submitted demucs_server_url has
+    # to persist, and the bad path is surfaced as a warning rather than a hard
+    # error that drops every other key.
+    missing = str(tmp_path / "does-not-exist")
+    r = client.post("/api/settings", json={
+        "dlc_dir": missing,
+        "demucs_server_url": "http://demucs.example:7865",
+        "default_arrangement": "Lead",
+    })
+    assert r.status_code == 200
+    body = r.json()
+    # No hard error; the bad path is reported as a warning.
+    assert "error" not in body
+    assert any("does-not-exist" in w for w in body.get("warnings", []))
+    assert "does-not-exist" in body["message"]
+    cfg = _read_cfg(tmp_path)
+    # The valid keys persisted...
+    assert cfg["demucs_server_url"] == "http://demucs.example:7865"
+    assert cfg["default_arrangement"] == "Lead"
+    # ...and the unresolvable path was NOT written.
+    assert cfg.get("dlc_dir", "") != missing
+
+
+def test_valid_dlc_dir_still_reports_song_count(client, tmp_path):
+    # The happy path is unchanged: a resolvable DLC dir persists and the
+    # response message still carries the "N song files found" summary (no
+    # warnings key when nothing went wrong).
+    dlc = tmp_path / "dlc"
+    dlc.mkdir()
+    r = client.post("/api/settings", json={"dlc_dir": str(dlc)})
+    assert r.status_code == 200
+    body = r.json()
+    assert "warnings" not in body
+    assert "song files found" in body["message"]
+    assert _read_cfg(tmp_path)["dlc_dir"] == str(dlc)
+
+
 @pytest.mark.parametrize("key", ["default_arrangement", "demucs_server_url"])
 def test_string_key_null_is_noop(client, tmp_path, key):
     # Match the dlc_dir contract: null preserves the on-disk value.


### PR DESCRIPTION
## Problem

Fixes got-feedBack/feedBack-demucs-server#3 — *"Can't Set Demucs Server Address"* (macOS 07-05 nightly).

The v3 Settings **Save** button next to the Demucs field posts `dlc_dir`, `default_arrangement`, `demucs_server_url` and `av_offset_ms` in a **single** request. `POST /api/settings` validated `dlc_dir` first and did an early `return {"error": "DLC directory not found"}` **before** it ever processed `demucs_server_url`. So on any machine whose DLC-folder path doesn't resolve (fresh install, unplugged external/network drive, a path carried over from another machine), clicking Save silently dropped the Demucs address. The Demucs input was also the only v3 setting with no per-field autosave, so that coupled button was the sole way to save it.

## Fix

- **server** (`server.py`): a non-resolving `dlc_dir` is now recorded as a warning and skipped instead of aborting the request — the co-submitted keys still persist. The bad path is surfaced via a new additive `warnings` field and folded into `message` so the settings status line still shows it. This also fixes the broader "one invalid field blocks the whole save" class of bug for the shared Save button.
- **client** (`static/v3/index.html`): the Demucs input autosaves on blur/enter via a single-key `persistSetting('demucs_server_url', …)` POST, like every other v3 setting, so it never depends on the coupled Save button. Save button kept for discoverability.
- **tests** (`tests/test_settings_api.py`): `test_unresolvable_dlc_dir_does_not_block_other_keys` + `test_valid_dlc_dir_still_reports_song_count`.

## Verification

- `pytest tests/test_settings_api.py` → 82 passed; `tests/test_settings_export.py` → 39 passed.
- `npm run test:js` → 1011 passed, 0 failed.
- Self-reviewed (high effort); fixed a stdlib-shadowing footgun (local list renamed off `warnings`). Codex preflight was unavailable (usage-limit reset) so a self-review was substituted.

## Follow-up (not in this PR)

The field is labeled *"Demucs server (for stem separation)"* but `demucs_server_url` only drives lyrics `/align` + vocal `/pitch`; **stem separation** is configured separately by the Studio plugin (`studio_demucs.json`). Either the label should be corrected or the field wired to feed the Studio config — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings now save even if the DLC folder path is missing or invalid, with a warning shown instead of blocking the update.
  * The Demucs server URL in Audio settings is now saved automatically when changed.

* **Bug Fixes**
  * Improved settings responses to include clearer warning text when the DLC folder can’t be found.
  * Other settings are still applied and saved even when the DLC folder path is not valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->