### PR TITLE
Accept spec lyrics_source values (authored, transcribed)

### DIFF
--- a/lib/sloppak.py
+++ b/lib/sloppak.py
@@ -703,20 +703,29 @@ def load_song(
                     and isinstance(e.get("d"), (int, float))
                 ]
                 if song.lyrics:
-                    # Provenance — populated by the converter (xml/notechart),
-                    # the WhisperX fallback (whisperx), or hand-edits
-                    # (user). Validate against the closed enum so a
-                    # hand-edited (or otherwise malformed) manifest can't
-                    # propagate a YAML dict / list / arbitrary string
-                    # into the highway WS `lyrics.source` field and out
-                    # to plugin badges. Anything outside the enum (or
-                    # the wrong type) falls back to "xml" — the spec's
-                    # back-compat default — instead of being stringified
-                    # and trusted.
-                    _ALLOWED_LYRICS_SOURCES = {"xml", "notechart", "whisperx", "user"}
-                    # Legacy alias: older manifests labelled note-chart-derived
-                    # lyrics with the source format's name; normalise it.
-                    _LYRICS_SOURCE_ALIASES = {"sng": "notechart"}
+                    # Provenance. The feedpak spec (§7.1) vocabulary is
+                    # {authored, transcribed, user}; older manifests + the
+                    # in-tree readers also use the source-format names
+                    # (xml/notechart) and the WhisperX engine name
+                    # (whisperx). Accept the union so both spec-compliant
+                    # writers (e.g. the stem_splitter plugin emitting
+                    # `transcribed`) and legacy packs validate. Validate
+                    # against the closed enum so a hand-edited (or otherwise
+                    # malformed) manifest can't propagate a YAML dict / list /
+                    # arbitrary string into the highway WS `lyrics.source`
+                    # field and out to plugin badges. Anything outside the
+                    # enum (or the wrong type) falls back to "xml" — the
+                    # back-compat default — instead of being stringified and
+                    # trusted.
+                    _ALLOWED_LYRICS_SOURCES = {
+                        "xml", "notechart", "whisperx", "user",
+                        "authored", "transcribed",
+                    }
+                    # Legacy aliases: older manifests labelled note-chart-derived
+                    # lyrics with the source format's name, and the WhisperX
+                    # fallback with the engine name — normalise both to the
+                    # spec vocabulary the badges now expect.
+                    _LYRICS_SOURCE_ALIASES = {"sng": "notechart", "whisperx": "transcribed"}
                     raw_source = manifest.get("lyrics_source")
                     if isinstance(raw_source, str):
                         raw_source = _LYRICS_SOURCE_ALIASES.get(raw_source, raw_source)

--- a/lib/sloppak.py
+++ b/lib/sloppak.py
@@ -717,8 +717,11 @@ def load_song(
                     # enum (or the wrong type) falls back to "xml" — the
                     # back-compat default — instead of being stringified and
                     # trusted.
+                    # Post-alias values only: `whisperx` is normalised to
+                    # `transcribed` before the membership check below, so (like
+                    # `sng`) it is intentionally absent from this set.
                     _ALLOWED_LYRICS_SOURCES = {
-                        "xml", "notechart", "whisperx", "user",
+                        "xml", "notechart", "user",
                         "authored", "transcribed",
                     }
                     # Legacy aliases: older manifests labelled note-chart-derived


### PR DESCRIPTION
## What

Widen `sloppak.py`'s `_ALLOWED_LYRICS_SOURCES` to include the feedpak spec §7.1 vocabulary (`authored`, `transcribed`) alongside the existing legacy values, and alias the legacy `whisperx` engine name to the spec's `transcribed`.

## Why

The reader only accepted `{xml, notechart, whisperx, user}` and silently downgraded anything else to `xml`. A spec-compliant writer — e.g. the new **stem_splitter** plugin, which sets `lyrics_source: transcribed` for WhisperX-produced lyrics per spec §7.1 — lost its provenance badge on load.

## Change

- `_ALLOWED_LYRICS_SOURCES` → union of spec vocabulary + legacy values (back-compat preserved).
- `_LYRICS_SOURCE_ALIASES` → add `whisperx → transcribed` so existing packs normalise to the spec badge.

Additive and back-compatible: every previously-valid value still validates. `has_lyrics` is unaffected either way.

## Test

- `tests/test_lyrics_transcribe.py` — 17 passed.
- `lib/sloppak.py` compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded support for additional lyric source values, including `authored` and `transcribed`.
  * Improved normalization of lyric source aliases so more manifest types are recognized consistently.
  * Continued to fall back to the default source when an invalid value is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->