### PR TITLE
fix(gp2rs): write beat times at 6-decimal precision so imported tempo matches Guitar Pro

### DIFF
--- a/lib/gp2rs.py
+++ b/lib/gp2rs.py
@@ -1114,7 +1114,7 @@ def _build_xml(
     ET.SubElement(root, "arrangement").text = arrangement
     ET.SubElement(root, "offset").text = f"{audio_offset:.3f}"
     ET.SubElement(root, "songLength").text = f"{song_length:.3f}"
-    ET.SubElement(root, "startBeat").text = f"{beats[0].time:.3f}" if beats else "0.000"
+    ET.SubElement(root, "startBeat").text = f"{beats[0].time:.6f}" if beats else "0.000000"
     ET.SubElement(root, "averageTempo").text = str(tempo)
     ET.SubElement(root, "artistName").text = artist
     ET.SubElement(root, "albumName").text = album
@@ -1139,10 +1139,17 @@ def _build_xml(
         tuning_el.set(f"string{i}", str(tuning[i] if i < len(tuning) else 0))
     ET.SubElement(root, "capo").text = "0"
 
-    # Ebeats
+    # Ebeats — write beat times at MICROSECOND (6-decimal) precision, not
+    # millisecond (3-decimal). The editor/timeline DERIVES per-bar BPM from beat
+    # spans (bpm = beats·60/span), which amplifies any rounding: at 3 decimals a
+    # constant-tempo GP (e.g. 140) shows a spurious ±0.05–0.7 BPM per-bar drift
+    # (worse for fast/odd meters) because most bar lengths don't land on a ms
+    # boundary. gp2rs computes these times exactly from the GP tempo map, so the
+    # only loss is this format string — 6 decimals makes the derived tempo match
+    # GP's authored value. (Everything else stays at :.3f; only beats drive tempo.)
     ebeats = ET.SubElement(root, "ebeats", count=str(len(beats)))
     for b in beats:
-        ET.SubElement(ebeats, "ebeat", time=f"{b.time:.3f}", measure=str(b.measure))
+        ET.SubElement(ebeats, "ebeat", time=f"{b.time:.6f}", measure=str(b.measure))
 
     # Sections
     sections_el = ET.SubElement(root, "sections", count=str(len(sections)))

--- a/tests/test_gp2rs.py
+++ b/tests/test_gp2rs.py
@@ -121,7 +121,10 @@ def _converter_ebeats(converter, numerator, denominator, tempo_changes=None):
 def _assert_ebeats(converter, numerator, denominator, expected_times, tempo_changes=None):
     ebeats = _converter_ebeats(converter, numerator, denominator, tempo_changes)
 
-    assert [ebeat.get("time") for ebeat in ebeats] == expected_times
+    # Compare by value, not string: beat times are written at 6-decimal
+    # (microsecond) precision so the derived per-bar tempo matches the authored
+    # GP value, but these tests only care about the spacing, not the format.
+    assert [float(ebeat.get("time")) for ebeat in ebeats] == [float(t) for t in expected_times]
     assert [ebeat.get("measure") for ebeat in ebeats] == [
         "1",
         *["-1"] * (len(expected_times) - 1),


### PR DESCRIPTION
## Problem

Importing a Guitar Pro file with a **constant** authored tempo produces a chart whose tempo **drifts slightly per bar** in the editor/timeline — e.g. a 140 BPM song shows bars at 139.94 / 140.02 / … (reported by testers on GP5 and GP8 files). Guitar Pro itself stores one exact tempo; we don't match it.

## Root cause

The editor/timeline **derives** per-bar BPM from beat spans (`bpm = beats·60 / span`). `gp2rs` computes beat times *exactly* from the GP tempo map, but writes them to the arrangement XML at **millisecond (3-decimal)** precision. Deriving BPM from ms-rounded spans amplifies the ±0.5 ms rounding into a **~0.05–0.7 BPM per-bar wobble** — worse for fast/odd meters (a 1-beat bar at 200 BPM can drift ~0.7). Most bar lengths don't land on a ms boundary, so nearly every constant-tempo import wobbles (125 BPM is a lucky exception — its bars *do* land on ms boundaries).

## Fix

Write `<ebeat>` / `<startBeat>` times at **6-decimal (microsecond)** precision. That's the only change — the times are already computed exactly; we were just truncating them on the way out. Everything else stays at `:.3f` (only beat times drive the tempo derivation).

## Verification

Ran the real `convert_file` on GP5 imports; derived per-bar BPM collapses from two drifting values to the single authored constant:

| File | before (3-decimal) | after (6-decimal) |
|---|---|---|
| Highway to Hell | 115.998 / 116.054 | **116.0** |
| Equivalence | 139.942 / 140.023 | **140.0** |
| Living After Midnight | 137.931 / 138.01 | **138.0** |

Companion editor-side PR (`feedback-plugin-editor`) matches the precision on the editor's save path so the drift can't return on save/reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JgxKh99UAeQqmhzSc73tv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exported XML timing precision: beat start times are now written with microsecond-level detail instead of millisecond-level.
  * Exported `ebeats` timing now preserves finer-grained beat times, reducing rounding-related precision loss.
* **Tests**
  * Updated tempo/tick conversion assertions to compare derived `ebeat` times numerically, making tests robust to serialization formatting differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->