### PR TITLE
Serve exact MIDI notes from GET /api/tunings (tuningMidis) — tuning-catalog convergence

### DIFF
--- a/lib/tunings.py
+++ b/lib/tunings.py
@@ -98,6 +98,22 @@ def open_midis_to_freqs(midis: list[int], reference_pitch: float = DEFAULT_REFER
     return [round(midi_to_freq(m, reference_pitch), 2) for m in midis]
 
 
+def freqs_to_midis(freqs: list[float], reference_pitch: float = DEFAULT_REFERENCE_PITCH) -> list[int] | None:
+    """Return absolute open-string MIDI notes for frequencies at the supplied
+    A4 reference — the inverse of open_midis_to_freqs. None if any entry is
+    non-numeric or non-positive (a provider could hand us anything)."""
+    out: list[int] = []
+    for f in freqs:
+        try:
+            f = float(f)
+        except (TypeError, ValueError):
+            return None
+        if f <= 0:
+            return None
+        out.append(int(round(69 + 12 * math.log2(f / reference_pitch))))
+    return out
+
+
 def tuning_offsets_from_midis(instrument_key: str, midis: list[int]) -> list[int] | None:
     """Return semitone offsets from the instrument's standard open strings."""
     standard = STANDARD_OPEN_MIDIS.get(instrument_key)

--- a/server.py
+++ b/server.py
@@ -45,9 +45,10 @@ from song import (
 from audio import find_wem_files, convert_wem
 from tunings import (
     DEFAULT_REFERENCE_PITCH, DEFAULT_TUNINGS, PROFILE_IDS, PROFILE_PATHWAYS,
-    apply_flat_instrument_patch_to_profiles, apply_reference_pitch,
-    normalize_instrument_profile, normalize_instrument_profiles,
-    settings_with_instrument_profiles, tuning_name,
+    TUNING_PRESET_MIDIS, apply_flat_instrument_patch_to_profiles,
+    apply_reference_pitch, freqs_to_midis, normalize_instrument_profile,
+    normalize_instrument_profiles, settings_with_instrument_profiles,
+    tuning_name,
 )
 import sloppak as sloppak_mod
 import drums as drums_mod
@@ -10766,7 +10767,25 @@ def get_tunings():
             ref = DEFAULT_REFERENCE_PITCH
     except (TypeError, ValueError):
         ref = DEFAULT_REFERENCE_PITCH
-    return {"referencePitch": ref, "tunings": tuning_providers.get_merged(ref)}
+    merged = tuning_providers.get_merged(ref)
+    # tuningMidis: the same catalog as exact integer MIDI notes (low → high).
+    # Built-ins come straight from TUNING_PRESET_MIDIS (no float round-trip);
+    # provider-contributed entries are recovered from their frequencies at the
+    # served reference pitch. Every consumer today (the v3 badges, plugins)
+    # reconstructs midis client-side via log2 — a rounding footgun at non-440
+    # references — so serve the integers once, host-side. Additive: the
+    # existing referencePitch/tunings shape is unchanged.
+    tuning_midis: dict[str, dict[str, list[int]]] = {}
+    for key, names in merged.items():
+        builtin = TUNING_PRESET_MIDIS.get(key, {})
+        resolved: dict[str, list[int]] = {}
+        for name, freqs in names.items():
+            midis = builtin.get(name) or freqs_to_midis(freqs, ref)
+            if midis:
+                resolved[name] = list(midis)
+        if resolved:
+            tuning_midis[key] = resolved
+    return {"referencePitch": ref, "tunings": merged, "tuningMidis": tuning_midis}
 
 
 @app.get("/api/settings")

--- a/tests/test_tunings.py
+++ b/tests/test_tunings.py
@@ -249,3 +249,30 @@ def test_flat_string_count_patch_resets_incompatible_named_tuning():
     patched = apply_flat_instrument_patch_to_profiles(settings, {"string_count": 7})
     assert patched["string_count"] == 7
     assert patched["tuning"] == "Standard"
+
+
+# ── freqs_to_midis (the /api/tunings tuningMidis inverse) ────────────────────
+
+def test_freqs_to_midis_round_trips_every_builtin_at_440():
+    from tunings import freqs_to_midis
+    for key, presets in TUNING_PRESET_MIDIS.items():
+        for name, midis in presets.items():
+            assert freqs_to_midis(open_midis_to_freqs(midis)) == midis, f"{key}/{name}"
+
+
+def test_freqs_to_midis_round_trips_at_nonstandard_reference():
+    # The consumer footgun this exists to kill: frequencies served at a 432/450
+    # reference must recover the SAME integer midis when inverted at that
+    # reference (client-side log2-at-440 reconstruction drifts here).
+    from tunings import freqs_to_midis
+    for ref in (430.0, 432.0, 444.0, 450.0):
+        for midis in (TUNING_PRESET_MIDIS["guitar-8"]["Standard"], TUNING_PRESET_MIDIS["bass-5"]["Standard"]):
+            freqs = open_midis_to_freqs(midis, ref)
+            assert freqs_to_midis(freqs, ref) == midis, f"ref={ref}"
+
+
+def test_freqs_to_midis_rejects_garbage():
+    from tunings import freqs_to_midis
+    assert freqs_to_midis([82.41, 0]) is None          # non-positive
+    assert freqs_to_midis([82.41, "x"]) is None        # non-numeric
+    assert freqs_to_midis([]) == []                    # vacuously fine


### PR DESCRIPTION
## The change (small, additive)

`GET /api/tunings` serves the catalog as **frequencies scaled to the reference pitch**, so every consumer that needs note identities reconstructs MIDI numbers client-side via `log2` — the v3 instrument badge does it for `TUNING_NOTE`, and Virtuoso now does it for its host-settings sync. That's N copies of a rounding footgun (it drifts at non-440 references) for something the host can serve once, exactly.

This PR adds `tuningMidis` to the response — the same catalog as **absolute open-string MIDI notes** (low → high, index 0 = lowest string):

```jsonc
{
  "referencePitch": 440.0,
  "tunings":     { "guitar-6": { "Standard": [82.41, …] } },   // unchanged
  "tuningMidis": { "guitar-6": { "Standard": [40, 45, 50, 55, 59, 64] } }  // new
}
```

- Built-ins come **straight from `TUNING_PRESET_MIDIS`** — no float round-trip at all.
- Provider-contributed tunings are inverted from their frequencies at the served reference via a new `freqs_to_midis()` (`lib/tunings.py`, the inverse of `open_midis_to_freqs`, garbage-guarded — a provider can hand us anything).
- Purely additive; `referencePitch`/`tunings` untouched.

**Tests:** every built-in round-trips at 440; round-trips hold at 430/432/444/450 (the exact case client reconstruction drifts on); garbage rejected. `tests/test_tunings.py` 50/50 green.

## Context — tuning-catalog convergence (the proposal this serves)

`TUNING_PRESET_MIDIS`'s own comment says the intent: *"absorbing the useful Virtuoso guitar/bass coverage into host-owned data so the host selector, tuner, practice tools, and plugins can converge on one profile model."* That absorption worked — the host table is now a **superset** of Virtuoso's named tunings — and Virtuoso v0.1.11 (feedBack-plugin-virtuoso#5) closes the loop from the plugin side: its instrument selector reads the host catalog (`/api/tunings`), persists through `POST /api/settings` + `workingTuning` + `instrument:changed`, and treats host settings as the source of truth for guitar/bass identity.

Two follow-ups would finish the convergence (proposals, not in this PR):

1. **Saved custom-tunings library.** The host settings hold one *current* custom offset-array, but there's no host-owned saved list. Virtuoso keeps its own (`virtuoso_tunings` DB table + a save-tuning flow) only because nothing host-side exists — a host `GET/POST /api/tunings/custom` (name + midis per instrument-key) would let plugins retire their private stores, and the tuner/badge would see user tunings too.
2. **Consumers adopt `tuningMidis`.** `badges.js` `loadTunings()` can drop `_freqToNote`'s log2 reconstruction and read the served integers (happy to do that as a follow-up PR if this shape lands).

Interop note for reviewers: absolute midis are the convergence currency deliberately — offset arrays are relative to each key's own standard (8-string base = F#), which is easy to get subtly wrong across consumers; integers by name are unambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MS2YFb6UUSwJVV6CmEa25i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MIDI note data to tuning information returned by the API.
  * Tuning frequencies can now be converted into MIDI notes, including support for custom reference pitches.

* **Bug Fixes**
  * Invalid or non-positive frequency values are safely rejected during conversion.

* **Tests**
  * Added coverage for standard and custom reference pitches, round-trip conversions, empty inputs, and invalid values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->