### PR TITLE
refactor(server): extract the audio-effects routes into routers/audio_effects.py (R3)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,8 +7,11 @@
 !server.py
 # The router seam server.py injects its singletons into (R3). Root-level Python
 # that ships in the image must be re-allowed explicitly — this file starts with
-# a blanket `*` exclusion. `routers/` needs the same treatment when it lands.
+# a blanket `*` exclusion.
 !appstate.py
+# Route modules extracted from server.py (R3).
+!routers/
+!routers/**
 !main.py
 !VERSION
 !tailwind.config.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`routers/` — the first extracted route module (R3).** The five audio-effects mapping
+  endpoints move out of `server.py` into `routers/audio_effects.py` as a
+  `fastapi.APIRouter`, mounted with `app.include_router(...)` **at the point in the file
+  where they used to be defined** — FastAPI matches routes in registration order, so the
+  mount site preserves it. Verified: the full 143-route table (paths, methods, *and*
+  order) is byte-for-byte identical to `main`. Bodies are verbatim; the only edits are
+  the decorator receiver (`@app.get` → `@router.get`) and the singleton read
+  (`audio_effect_mappings` → `appstate.audio_effect_mappings`, a module attribute
+  resolved at call time). This proves the seam from #833 under a real consumer, including
+  the second slot. The `_demo_mode_guard` middleware still blocks all four moved write
+  routes with 403, and `Query(...)` validation still 422s — both checked against a running
+  server. Ships via `COPY routers/ /app/routers/` plus `!routers/` + `!routers/**` in
+  `.dockerignore`. `server.py`: **9,445 → 9,386 lines**.
 - **`appstate.py` — the router seam (R3).** Route modules moving out of `server.py`
   need `meta_db` and friends but must not `import server`, or the import graph goes
   circular the moment `server` imports them back. So `server.py` keeps *constructing*

--- a/Dockerfile
+++ b/Dockerfile
@@ -209,6 +209,7 @@ COPY server.py /app/
 # The router seam server.py injects its singletons into (R3). Root-level, like
 # server.py, so `import appstate` resolves off PYTHONPATH=/app.
 COPY appstate.py /app/
+COPY routers/ /app/routers/
 COPY main.py /app/
 COPY VERSION /app/
 # Built-in diagnostic sloppaks seeded into DLC_DIR/diagnostics-builtin/ at scan

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ./static:/app/static
       - ./server.py:/app/server.py
       - ./appstate.py:/app/appstate.py
+      - ./routers:/app/routers
       - ./VERSION:/app/VERSION
       - ./ug_browser.py:/app/ug_browser.py
       - ./lib:/app/lib

--- a/docs/size-exemptions.md
+++ b/docs/size-exemptions.md
@@ -55,8 +55,8 @@ without a *signed* exemption" is unenforceable.
 ## Planned, NOT exempt (owned by split plans — listed so nothing falls between states)
 
 core `static/app.js` (11,852) · `static/highway.js` (4,168, whole file) · `server.py`
-(9,445 — was 14,037; ratcheted by the R3 `MetadataDB` + `AudioEffectsMappingDB`
-extractions, plus 12 lines for the `appstate.py` seam) ·
+(9,386 — was 14,037; ratcheted by the R3 `MetadataDB` + `AudioEffectsMappingDB`
+extractions and the first `routers/` module) ·
 `lib/metadata_db.py` (4,373 — new in R3; the `MetadataDB` class alone is 4,018 lines
 and is a monolith in its own right, to be split per-table once the router train
 lands) · `static/v3/songs.js` (4,134) · `static/capabilities/audio-session.js`

--- a/routers/__init__.py
+++ b/routers/__init__.py
@@ -1,0 +1,22 @@
+"""FastAPI route modules extracted from ``server.py`` (R3).
+
+Each module here exposes a module-level ``router`` (a ``fastapi.APIRouter``)
+that ``server.py`` mounts with ``app.include_router(...)`` at the point in the
+file where those routes used to be defined — FastAPI matches routes in
+registration order, so keeping the mount site preserves it.
+
+**Routers must never ``import server``.** They reach core singletons through
+the injected seam instead::
+
+    import appstate
+
+    @router.get("/api/thing")
+    def get_thing():
+        return appstate.meta_db.thing()
+
+and always as a **module attribute, at call time** — never
+``from appstate import meta_db``, which freezes the binding and defeats both a
+later ``appstate.configure()`` and ``monkeypatch.setattr``. See ``appstate.py``.
+
+Dependencies flow one way: ``server -> routers -> appstate``.
+"""

--- a/routers/audio_effects.py
+++ b/routers/audio_effects.py
@@ -1,0 +1,80 @@
+"""Audio-effects mapping API — the core-owned song/tone -> provider routing index.
+
+Extracted verbatim from ``server.py`` (R3); only the decorator receiver
+(``@app`` -> ``@router``) and the singleton read (``audio_effect_mappings`` ->
+``appstate.audio_effect_mappings``) changed. The read must stay a module
+attribute so a re-imported ``server`` re-publishes a fresh DB into the seam and
+`monkeypatch.setattr` reaches this module — see ``appstate.py``.
+"""
+
+from fastapi import APIRouter, Body, Query
+from fastapi.responses import JSONResponse
+
+import appstate
+
+router = APIRouter()
+
+
+def _audio_effects_error(exc: Exception):
+    return JSONResponse({"error": str(exc)}, status_code=400)
+
+
+@router.get("/api/audio-effects/mappings")
+def list_audio_effect_mappings(
+    song_key: str = Query(""),
+    filename: str = Query(""),
+    tone_key: str = Query(""),
+    provider_id: str = Query(""),
+):
+    try:
+        return {
+            "mappings": appstate.audio_effect_mappings.list(
+                song_key=song_key,
+                filename=filename,
+                tone_key=tone_key,
+                provider_id=provider_id,
+            )
+        }
+    except ValueError as exc:
+        return _audio_effects_error(exc)
+
+
+@router.post("/api/audio-effects/mappings")
+def upsert_audio_effect_mapping(data: dict = Body(...)):
+    try:
+        mapping = appstate.audio_effect_mappings.upsert(data)
+    except ValueError as exc:
+        return _audio_effects_error(exc)
+    return {"ok": True, "mapping": mapping}
+
+
+@router.delete("/api/audio-effects/mappings/{mapping_id}")
+def delete_audio_effect_mapping(mapping_id: int, provider_id: str = Query("")):
+    try:
+        deleted = appstate.audio_effect_mappings.delete(mapping_id, provider_id=provider_id)
+    except ValueError as exc:
+        return _audio_effects_error(exc)
+    if not deleted:
+        return JSONResponse({"error": "mapping not found"}, status_code=404)
+    return {"ok": True}
+
+
+@router.post("/api/audio-effects/mappings/{mapping_id}/activate")
+def activate_audio_effect_mapping(mapping_id: int, data: dict = Body(default_factory=dict)):
+    try:
+        provider_id = data.get("provider_id") if "provider_id" in data else data.get("providerId")
+        mapping = appstate.audio_effect_mappings.activate(mapping_id, provider_id="" if provider_id is None else provider_id)
+    except ValueError as exc:
+        return _audio_effects_error(exc)
+    if not mapping:
+        return JSONResponse({"error": "mapping not found"}, status_code=404)
+    return {"ok": True, "mapping": mapping}
+
+
+@router.delete("/api/audio-effects/active-mapping")
+def clear_audio_effect_active_mapping(song_key: str = Query(...), tone_key: str = Query("")):
+    try:
+        cleared = appstate.audio_effect_mappings.clear_active(song_key=song_key, tone_key=tone_key)
+    except ValueError as exc:
+        return _audio_effects_error(exc)
+    return {"ok": True, "cleared": cleared}

--- a/server.py
+++ b/server.py
@@ -21,7 +21,7 @@ configure_logging()
 
 log = logging.getLogger("feedBack.server")
 
-from fastapi import Body, FastAPI, WebSocket, WebSocketDisconnect, UploadFile, File, HTTPException, Query
+from fastapi import Body, FastAPI, WebSocket, WebSocketDisconnect, UploadFile, File, HTTPException
 from fastapi.concurrency import run_in_threadpool
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse, JSONResponse, RedirectResponse, Response, StreamingResponse
@@ -69,6 +69,8 @@ from audio_effects_db import AudioEffectsMappingDB
 # The router seam. Imported as a module (never `from appstate import ...`) so
 # `appstate.configure(...)` below publishes into the same namespace routers read.
 import appstate
+# Extracted route modules. They import `appstate`, never `server` — one-way graph.
+from routers import audio_effects
 import sloppak as sloppak_mod
 import drums as drums_mod
 import notation as notation_mod
@@ -5991,70 +5993,9 @@ def delete_loop(loop_id: int):
 
 
 # ── Audio Effects Mapping API ───────────────────────────────────────────────
-
-def _audio_effects_error(exc: Exception):
-    return JSONResponse({"error": str(exc)}, status_code=400)
-
-
-@app.get("/api/audio-effects/mappings")
-def list_audio_effect_mappings(
-    song_key: str = Query(""),
-    filename: str = Query(""),
-    tone_key: str = Query(""),
-    provider_id: str = Query(""),
-):
-    try:
-        return {
-            "mappings": audio_effect_mappings.list(
-                song_key=song_key,
-                filename=filename,
-                tone_key=tone_key,
-                provider_id=provider_id,
-            )
-        }
-    except ValueError as exc:
-        return _audio_effects_error(exc)
-
-
-@app.post("/api/audio-effects/mappings")
-def upsert_audio_effect_mapping(data: dict = Body(...)):
-    try:
-        mapping = audio_effect_mappings.upsert(data)
-    except ValueError as exc:
-        return _audio_effects_error(exc)
-    return {"ok": True, "mapping": mapping}
-
-
-@app.delete("/api/audio-effects/mappings/{mapping_id}")
-def delete_audio_effect_mapping(mapping_id: int, provider_id: str = Query("")):
-    try:
-        deleted = audio_effect_mappings.delete(mapping_id, provider_id=provider_id)
-    except ValueError as exc:
-        return _audio_effects_error(exc)
-    if not deleted:
-        return JSONResponse({"error": "mapping not found"}, status_code=404)
-    return {"ok": True}
-
-
-@app.post("/api/audio-effects/mappings/{mapping_id}/activate")
-def activate_audio_effect_mapping(mapping_id: int, data: dict = Body(default_factory=dict)):
-    try:
-        provider_id = data.get("provider_id") if "provider_id" in data else data.get("providerId")
-        mapping = audio_effect_mappings.activate(mapping_id, provider_id="" if provider_id is None else provider_id)
-    except ValueError as exc:
-        return _audio_effects_error(exc)
-    if not mapping:
-        return JSONResponse({"error": "mapping not found"}, status_code=404)
-    return {"ok": True, "mapping": mapping}
-
-
-@app.delete("/api/audio-effects/active-mapping")
-def clear_audio_effect_active_mapping(song_key: str = Query(...), tone_key: str = Query("")):
-    try:
-        cleared = audio_effect_mappings.clear_active(song_key=song_key, tone_key=tone_key)
-    except ValueError as exc:
-        return _audio_effects_error(exc)
-    return {"ok": True, "cleared": cleared}
+# Mounted here, where these routes used to be defined: FastAPI matches in
+# registration order, so the mount site preserves it.
+app.include_router(audio_effects.router)
 
 
 # ── Settings API ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
The **first route module** through the `appstate` seam from #833. Move-only, backend-only.

## Picked by measurement, not by the plan

The plan assumed `artists/aliases` was the cheapest first router. A transitive dependency-closure scan over every route group says otherwise — `api_artist_links` reaches `_mb_http_get` **and** `_enrich_network_enabled`, both `monkeypatch.setattr` targets (13 + 15 sites). Ranking every group by (`setattr` targets, helpers needing relocation):

| group | routes | lines | setattr | helpers to relocate |
|---|---|---|---|---|
| artist-aliases | 5 | 37 | 0 | none |
| loops | 3 | 30 | 0 | none |
| **audio-effects** | **5** | **46** | **0** | **`_audio_effects_error` (exclusive)** |
| artist-page/links | 3 | 13 | **2** | 19 |
| song | 14 | 644 | **11** | 95 |

`audio-effects` wins as the first cut: zero `setattr` targets, one exclusive helper, and — unlike the alias group — it exercises the **second** seam slot (`audio_effect_mappings`, not `meta_db`) *and* the `_demo_mode_guard` middleware, which has four regexes pointed at these exact paths.

## What changed

Bodies are verbatim. Two mechanical edits, nothing else:

```
@app.get(...)             ->  @router.get(...)
audio_effect_mappings.x   ->  appstate.audio_effect_mappings.x
```

The singleton read stays a **module attribute resolved at call time**, so a re-imported `server` re-publishes a fresh DB into the seam and `monkeypatch.setattr` reaches this module. `routers/` never imports `server`: the graph is `server → routers → appstate`.

`app.include_router(...)` sits **exactly where the routes used to be defined**. FastAPI matches in registration order, so the mount site is load-bearing.

**`server.py`: 9,445 → 9,386 lines.** `fastapi.Query` went dead with the move and was removed; the other four unused imports are pre-existing on `main`.

## Verification

- **Route table diffed against `origin/main`**: 143 routes, **identical paths, methods, and registration order**. This is the assertion that matters for `include_router`.
- **Boot smoke drives all five routes end-to-end**: create → read back → activate → clear-active → delete → `404` on a missing id → `400` on a bad body. `Query(...)` still `422`s a missing required param.
- **Demo-mode middleware** still `403`s all four moved write routes and still allows the read — checked against a running server with `FEEDBACK_DEMO_MODE=1`.
- **Docker**: `COPY routers/ /app/routers/` plus `!routers/` + `!routers/**` in `.dockerignore` (that file opens with a blanket `*` exclusion, so a new package is invisible to the build without it — this is what would have broken the image). Verified against the real daemon: `routers/` reaches the build context, `__pycache__` does not.
- `pytest` **2348 passed** (75 across the audio-effects + demo-mode suites); `pyflakes` clean on `routers/`; `npm run lint` 0 errors.
- **Codex preflight**: 0 findings.

## Pattern for the rest of the train

`routers/__init__.py` documents it: expose a module-level `router`, read singletons as `appstate.<name>` at call time, never `from appstate import …` (frozen binding), never `import server`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio-effects mapping API endpoints for listing, creating, updating, activating, and deleting mappings.
  * Added filtering and validation support for audio-effects mapping requests.
  * Preserved existing error responses and route behavior.

* **Infrastructure**
  * Updated Docker packaging and local development mounts so the new API routes are included at runtime.

* **Documentation**
  * Updated the changelog and project size-exemption documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->