### PR TITLE
refactor(ui): load the capabilities as ES modules (R3a)

### DIFF
--- a/static/v3/index.html
+++ b/static/v3/index.html
@@ -119,19 +119,19 @@
          script logs anything; load it as early as possible. See
          docs/diagnostics-bundle-spec.md (feedBack#166). -->
     <script defer src="/static/diagnostics.js"></script>
-    <script defer src="/static/capabilities.js"></script>
-    <script defer src="/static/capabilities/library.js"></script>
-    <script defer src="/static/capabilities/tuning.js"></script>
-    <script defer src="/static/capabilities/working-tuning.js"></script>
-    <script defer src="/static/capabilities/audio-session.js"></script>
-    <script defer src="/static/capabilities/audio-effects.js"></script>
-    <script defer src="/static/capabilities/playback.js"></script>
+    <script type="module" src="/static/capabilities.js"></script>
+    <script type="module" src="/static/capabilities/library.js"></script>
+    <script type="module" src="/static/capabilities/tuning.js"></script>
+    <script type="module" src="/static/capabilities/working-tuning.js"></script>
+    <script type="module" src="/static/capabilities/audio-session.js"></script>
+    <script type="module" src="/static/capabilities/audio-effects.js"></script>
+    <script type="module" src="/static/capabilities/playback.js"></script>
     <!-- fee[dB]ack v0.3.0: ui.library-card-injection capability (plugin card actions). -->
-    <script defer src="/static/capabilities/library-card-actions.js"></script>
-    <script defer src="/static/capabilities/visualization.js"></script>
-    <script defer src="/static/capabilities/note-detection.js"></script>
-    <script defer src="/static/capabilities/midi-input.js"></script>
-    <script defer src="/static/capabilities/interface-scale.js"></script>
+    <script type="module" src="/static/capabilities/library-card-actions.js"></script>
+    <script type="module" src="/static/capabilities/visualization.js"></script>
+    <script type="module" src="/static/capabilities/note-detection.js"></script>
+    <script type="module" src="/static/capabilities/midi-input.js"></script>
+    <script type="module" src="/static/capabilities/interface-scale.js"></script>
 </head>
 <body class="h-screen flex overflow-hidden bg-fb-sidebar text-fb-text font-display">
 


### PR DESCRIPTION
Step 3 of the core-frontend ES-module migration (**R3a**), on top of #871/#872/#874. **One file, 12 lines** — the capability `<script>` tags become `type="module"`. No JS changes.

## Why it's safe

The capability scripts already communicate **only** through the `window.feedBack` bus: they self-register, version-negotiate (`capabilities.version !== 1` → bail), and self-guard for idempotency. They never import or call app.js — it's pure pub/sub.

I checked they export nothing by name: **no top-level declaration** in `capabilities.js` or `capabilities/*.js` is read by any other script, so losing global scope costs nothing.

## This is the first real exercise of #872's ordering fix

A module defers to after HTML parse. So the capabilities now execute **after** the document is parsed — while `app.js` still calls `window.feedBack.on(...)` at its **top level** (11 sites).

That only works because #872 put every classic script into the **same deferred queue**, where document order *is* execution order: `capabilities.js` (line 122) still runs before `app.js` (line 1237).

Had app.js stayed a plain classic script, it would have run *during* parse — ahead of the deferred capability modules — hit the bare `{}` from `window.feedBack = window.feedBack || {}`, and died on `window.feedBack.on is not a function`. That is precisely the failure the original plan's "zero-risk warm-up" would have shipped, and why #872 came first.

## Verification

**A/B against `origin/main`**, 11 probes — `capabilities.version`, registered **participants (37)**, **compatibility shims (14)**, the bus, `workingTuning`, `theme`, `setViz` / `showScreen` / `playSong`, mounted plugin screens:

**IDENTICAL on every probe. Zero console/page errors on both.**

12 `<script type="module">` tags served and executed; 5 plugin screens still mount. pytest **2396**, node **1032/1032**, ESLint **0 errors**, tailwind-fresh clean, Codex preflight **0**.

Next: **app.js → `type="module"`** — the flip, with the boot-a-plugin hard gate (app.js *is* the plugin loader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading and initialization of capability-related functionality.
  * Enhanced reliability for interface scaling and library card actions.
  * Updated capability components to use modern browser loading behavior for smoother performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->