### PR TITLE
refactor(ui): load app.js as an ES module (R3a) — the flip

### DIFF
--- a/static/v3/index.html
+++ b/static/v3/index.html
@@ -1244,7 +1244,7 @@
     <script defer src="/static/highway.js"></script>
     <script defer src="/static/vendor/lottie.min.js"></script>
     <script defer src="/static/lottie-api.js"></script>
-    <script defer src="/static/app.js"></script>
+    <script type="module" src="/static/app.js"></script>
     <script defer src="/static/audio-mixer.js"></script>
     <script defer src="/static/vendor/shepherd.min.js"></script>
     <script defer src="/static/tour-engine.js"></script>


### PR DESCRIPTION
**The flip.** One attribute. #871, #872, #874 and #875 exist to make this line safe.

```diff
-<script defer src="/static/app.js"></script>
+<script type="module" src="/static/app.js"></script>
```

After this, `app.js` can `import` — the monolith-killing *enabler* is done, and carving it into `static/js/*.js` becomes routine follow-on work.

## What changes

app.js's **385 top-level `function` declarations** stop being implicit `window` properties:
- **87** stay reachable through the explicit contract — #874's `Object.assign` block **plus 47 pre-existing scattered `window.X = X` assignments**
- **298** become module-private

Verified: **no unexposed name is read from outside app.js.**

## Strict mode

Modules are always strict, and app.js has never run under it. Checked before flipping:

- parses clean as `sourceType: "module"` (no octal literals, duplicate params, `with`)
- no implicit globals, no `eval` / `new Function`, no top-level `this`
- **`registerShortcut`** is called **bare** at 15 top-level sites. It's assigned at `window.registerShortcut` (`app.js:10387`), *before* its first call (`10648`), and a bare identifier in a module still resolves through the global object. Confirmed `typeof window.registerShortcut === 'function'` in the browser.

## Hard gate — app.js *is* the plugin loader

| check | result |
|---|---|
| `/api/plugins` `script_type` passthrough | editor / stems / studio = `"module"` |
| `/api/plugins/stems/src/main.js` | **200** |
| conditional GET (live-edit ETag) | **304** |
| deep graph: `stems/src/transport.js`, `editor/src/state.js` | **200** |
| `window.loadPlugins` | `function` |
| plugin screens mounted | 5 |
| migrated plugins injected as `<script type="module">` | editor, studio, stems |
| capability participants / compat shims | 37 / 14 |

**All 336 inline handlers in the shell resolve on `window`** under module scope; the A–Z rail and pagination execute **6/6** with no ReferenceError.

A/B against `origin/main`: the only unresolvable handler is **`editorToggleStemMixer`** — **equally broken on main**. It's a dead handler in the editor plugin (not defined anywhere in its source — looks like rename skew). Pre-existing, unrelated to this PR, worth its own issue.

## Codex preflight — one [P1], a false positive

Codex claimed `restartCurrentSong`, `requestExitSong`, `editRegionInEditor` and `returnToEditorFromHighway` would `ReferenceError` because they're absent from #874's `Object.assign` block.

They are absent from it — because they were **already** explicit, among app.js's 47 scattered `window.X = X` assignments:

```
app.js:7086  window.restartCurrentSong = restartCurrentSong;
app.js:7204  window.requestExitSong = requestExitSong;
app.js:8492  window.editRegionInEditor = editRegionInEditor;
app.js:8511  window.returnToEditorFromHighway = returnToEditorFromHighway;
```

With app.js loaded as `type="module"`, all four resolve as `function` in the browser, and `requestExitSong()` is live as a real `onclick` source. The contract test already covers this — it collects **both** the scattered assignments and the block. Codex's scan only read the block.

## Suites

pytest **2396 passed** · node **1032/1032** · ESLint **0 errors** · tailwind-fresh clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application startup behavior by updating how the app’s main script loads in the browser.
  * Enables modern module-based loading for better compatibility and execution handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->