### PR TITLE
refactor(app): give the <audio> element a module of its own (R3a)

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -39,6 +39,7 @@ import {
     exportSettings,
     importSettings,
 } from './js/settings-io.js';
+import { audio } from './js/audio-el.js';
 
 // Demo analytics — real impl set by demo.js; no-op in normal builds
 window.feedBackDemoTrack = window.feedBackDemoTrack ?? null;
@@ -3419,7 +3420,9 @@ function retuneSong(filename, title, tuning, target) {
 }
 
 // ── Player ───────────────────────────────────────────────────────────────
-const audio = document.getElementById('audio');
+// `audio` now lives in ./js/audio-el.js so carved-out modules can reach the
+// player without importing app.js back (which would close a cycle). Same
+// element, same handle, same lookup — just imported instead of declared here.
 let isPlaying = false;
 let _lastSongPositionEventAt = 0;
 

--- a/static/js/audio-el.js
+++ b/static/js/audio-el.js
@@ -1,0 +1,17 @@
+// The one <audio> element the whole app plays through.
+//
+// This exists so that code carved out of app.js can reach the player without
+// importing app.js back — which would close a cycle and fail the import-x/no-cycle
+// gate. It is the same handle app.js has always held (`document.getElementById`
+// on the element in the shell), just given a home of its own.
+//
+// It is deliberately a `const`, and it is never reassigned anywhere in core — so a
+// read-only import binding is exactly right, and no state container is needed.
+// (Contrast the reassigned scalars — isPlaying, _avOffsetMs, … — which cannot be
+// shared this way, because an imported binding cannot be written to.)
+//
+// Module scripts evaluate after the HTML is parsed, so the element is already in
+// the document by the time this runs. app.js is loaded as <script type="module">,
+// and its imports evaluate before its body — the same point at which app.js used
+// to run this exact lookup itself.
+export const audio = document.getElementById('audio');


### PR DESCRIPTION
`static/js/audio-el.js` — **one exported const**. app.js's diff is **5 lines**.

**This is a hinge, not a carve.** Nothing shrinks. But almost everything left in app.js is blocked behind it.

## Why

`audio` is `document.getElementById('audio')` — **162 references in app.js**, 173 outside any single cluster.

Every remaining cluster I measured lists `audio` among its inbound symbols:

| cluster | fns | inbound |
|---|---|---|
| settings + app-updates | 20 | 10 — incl. `audio` |
| count-in | 208 | 119 — incl. `audio` |
| exit-confirm | 212 | 120 — incl. `audio` |
| library-render | 220 | 126 — incl. `audio` |

They all touch playback, and playback reaches for the element **directly**. A carved module can't import app.js to get it — that closes a cycle and fails `import-x/no-cycle`. So today the only way to carve any of them is a **host seam**: exactly the thing #878 had to build and #880 had to tear out.

Giving `audio` a home removes that from every one of them at once.

## Why it's safe

`audio` is a **`const`**, and it is **never reassigned anywhere in core**. So a read-only import binding is precisely right — no state container needed. The 162 call sites are **untouched**: the binding keeps its name, it's just imported instead of declared.

Contrast the *reassigned* scalars (`isPlaying`, `_avOffsetMs`, …). Those **cannot** be shared this way, because an imported binding cannot be written to. They still need containers — that's the next problem, and deliberately not this one.

## Timing

app.js is `<script type="module">`, so it evaluates after the HTML is parsed, and its imports evaluate just before its body — **the same moment app.js used to run this exact lookup itself**.

If the element weren't in the document yet, `audio` would be `null` and app.js's top-level `audio.addEventListener(...)` calls would throw and kill the whole module. They don't — which is itself the proof.

## Verified with real playback

A/B against `origin/main` in two browsers:

| | main | carved |
|---|---|---|
| app alive, **zero page errors** (⇒ the import resolved) | ✓ | **identical** |
| `#audio` element | `AUDIO` | **identical** |
| `togglePlay` / `seekBy` | `function` | **identical** |
| **`playSong()` on a real library song → `audio.src` set** | ✓ | **identical** |
| **element reports a duration** | ✓ | **identical** |

pytest **2396** · node **1038/1038** · ESLint **0** (no-cycle clean) · tailwind clean · Codex **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved audio player module sharing for more consistent playback behavior.
  * Preserved existing player functionality while centralizing access to the audio element.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->