### PR TITLE
fix(static): raw stereo loopback capture — no voice-call DSP (tin-can fix)

### DIFF
--- a/static/js/juce-audio.js
+++ b/static/js/juce-audio.js
@@ -614,9 +614,22 @@ import { S } from './player-state.js';
     let _lbStream = null, _lbCtx = null, _lbTap = null, _lbPageMuted = false;
     let _loopbackUnavailable = false;   // sticky: probe once, then fall back
     async function _engageLoopback() {
+        // Chromium's default capture pipeline treats the audio track as a
+        // VOICE call: echo cancellation + noise suppression + AGC + mono
+        // downmix. On music that is the "tin can" sound (tester 2026-07-12).
+        // Request the raw stereo path explicitly — every constraint here is
+        // best-effort (ideal-valued), so unsupported ones degrade silently
+        // rather than failing the capture.
         const stream = await navigator.mediaDevices.getDisplayMedia({
             video: true,
-            audio: { suppressLocalAudioPlayback: true },
+            audio: {
+                suppressLocalAudioPlayback: true,
+                echoCancellation: false,
+                noiseSuppression: false,
+                autoGainControl: false,
+                channelCount: 2,
+                sampleRate: 48000,
+            },
         });
         for (const t of stream.getVideoTracks()) t.stop();   // required, unused
         const track = stream.getAudioTracks()[0];
@@ -637,8 +650,19 @@ import { S } from './player-state.js';
                 _lbPageMuted = (await api.setPageMuted(true)) === true;
             }
             if (window._asioDiagEnabled?.()) {
+                // Full track settings: shows whether the raw-audio constraints
+                // (no EC/NS/AGC, stereo) actually took — a track that still
+                // reports echoCancellation=true or channelCount=1 explains
+                // "tin can" quality reports directly from the log.
+                const s = track.getSettings?.() || {};
                 console.log('[asio-diag] loopback: suppressed=', suppressed,
-                    'pageMuted=', _lbPageMuted, 'rate=', _lbCtx.sampleRate);
+                    'pageMuted=', _lbPageMuted, 'rate=', _lbCtx.sampleRate,
+                    'track=', JSON.stringify({
+                        sampleRate: s.sampleRate, channelCount: s.channelCount,
+                        echoCancellation: s.echoCancellation,
+                        noiseSuppression: s.noiseSuppression,
+                        autoGainControl: s.autoGainControl,
+                    }));
             }
             await api.setRendererBus(true, 1.0);
             tap.active = true;


### PR DESCRIPTION
## Problem

After the loopback-permission fix (feedBack-desktop #100), song-preview audio reached ASIO and the streamer WASAPI output — but sounded like a tin can. Chromium applies voice-call processing (echo cancellation, noise suppression, AGC, mono downmix) to `getDisplayMedia` audio tracks by default.

## Fix

`_engageLoopback` now requests `echoCancellation:false, noiseSuppression:false, autoGainControl:false, channelCount:2, sampleRate:48000`. All best-effort (ideal-valued): unsupported constraints degrade silently rather than failing the capture. The `[asio-diag] loopback:` line now dumps the track's effective `getSettings()` so tester logs prove which processing applied.

## Verification

Packaged portable build (fix16), ASIO4ALL:

```
[asio-diag] loopback: suppressed= true pageMuted= false rate= 48000 track= {"sampleRate":48000,"channelCount":2,"echoCancellation":false,"noiseSuppression":false,"autoGainControl":false}
[renderer-bus] engaged: app loopback → engine bus
```

Tester confirms clean preview audio on ASIO + streamer output.

Companion desktop PR: got-feedBack/feedBack-desktop#100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop audio loopback capture for cleaner stereo music recording.
  * Audio capture now requests reduced processing, including disabled echo cancellation, noise suppression, and automatic gain control.
  * Added best-effort support for two-channel, 48 kHz audio capture.
* **Diagnostics**
  * Expanded optional audio diagnostics with detailed capture settings, including sample rate, channel count, and processing flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->