### PR TITLE
Skip hidden (dot-prefixed) directories in the library scan

### DIFF
--- a/lib/scan.py
+++ b/lib/scan.py
@@ -135,7 +135,7 @@ def background_scan():
         # Both are kept out of the scan; _resolve_dlc_path still loads them by
         # path for playback.
         def _is_excluded_from_library(p: Path) -> bool:
-            return "tutorials-builtin" in p.parts or "minigames-builtin" in p.parts
+            return "tutorials-builtin" in p.parts or "minigames-builtin" in p.parts or any(part.startswith(".") for part in p.relative_to(dlc).parts)
         # Sloppaks: match both file (zip) and directory form, across both the
         # `.feedpak` and legacy `.sloppak` suffixes.
         _cands = sorted(p for ext in sloppak_mod.SONG_EXTS for p in dlc.rglob(f"*{ext}"))


### PR DESCRIPTION
The library scanner descends into hidden (dot-prefixed) directories, so a plugin that keeps an on-disk cache or working files under a `.`-prefixed folder in the DLC root has those files indexed as library songs (surfacing as duplicates in the library). This excludes any path with a hidden component below the DLC root, alongside the existing `tutorials-builtin` / `minigames-builtin` carve-outs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hidden folders within the DLC directory are now excluded from library listings.
  * Built-in tutorial and minigame folders continue to be omitted from scan results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->