### PR TITLE
refactor(highway): flip highway.js to an ES module (R3c)

### DIFF
--- a/static/highway.js
+++ b/static/highway.js
@@ -4240,6 +4240,21 @@ function createHighway() {
 }
 const highway = createHighway();
 window.highway = highway; // expose for plugins
+
+// THE FACTORY IS PART OF THE PUBLIC CONTRACT, and a classic script gave it to us for free.
+//
+// A top-level `function createHighway()` in a CLASSIC script implicitly becomes
+// window.createHighway. In a MODULE it does not — module declarations are module-scoped, and
+// the name would silently vanish from the global object the moment this file grew a
+// type="module" attribute. The constitution names window.createHighway as public extension
+// contract (alongside window.playSong / showScreen / feedBack), and plugins that render their
+// own highway panel construct a second instance with it. Nothing in-tree calls it, which is
+// exactly why this would have shipped: the only consumers are third-party, and I cannot grep
+// those.
+//
+// So it is assigned explicitly now. Same object, same behaviour, no longer an accident of how
+// the file happens to be loaded.
+window.createHighway = createHighway;
 highway.setOnLyricsChange(function(visible) {
     const btn = document.getElementById('btn-lyrics');
     if (btn) {

--- a/static/v3/index.html
+++ b/static/v3/index.html
@@ -1241,7 +1241,7 @@
     </main>
     <!-- /#v3-main -->
 
-    <script defer src="/static/highway.js"></script>
+    <script type="module" src="/static/highway.js"></script>
     <script defer src="/static/vendor/lottie.min.js"></script>
     <script defer src="/static/lottie-api.js"></script>
     <script type="module" src="/static/app.js"></script>


### PR DESCRIPTION
Two lines. `index.html`: `defer` → `type="module"`. `highway.js`: one explicit assignment.

**highway.js can now `import`** — which is the whole point. The carve can begin.

## The one thing the flip actually breaks: `window.createHighway`

A top-level `function createHighway()` in a **classic script** *implicitly* becomes `window.createHighway`. In a **module** it does not — module declarations are module-scoped, and the name **vanishes from the global object** the instant the tag grows `type="module"`.

The constitution names `window.createHighway` as **public extension contract** (alongside `window.playSong` / `showScreen` / `feedBack`).

**Nothing in-tree calls it.** That is exactly why this would have shipped: the only consumers are third-party plugins rendering their own highway panel, and I cannot grep those. Green CI, green tests, and a broken plugin API.

Verified by removing the assignment and reloading:

```
flip WITHOUT an explicit assignment:  window.createHighway === undefined   <-- contract gone
flip WITH it:                         window.createHighway === function
```

So it's assigned explicitly now — same object, same behaviour, no longer an accident of how the file happens to be loaded.

## A correction to #912

**#912 (merged) was over-sold, and I want that on the record.**

It rewrote 73 bare `highway.x` → `window.highway.x` on the stated grounds that the flip would turn every one of them into a `ReferenceError`.

**Having now actually flipped it: that was wrong.** `highway.js` already did `window.highway = highway`, which puts the name on the **global object** — and bare-identifier resolution falls back to the global object whether or not a *lexical* global binding exists. Measured on both builds: bare `highway` resolves either way.

#912 is defensible as hygiene and it does no harm, but it was **not a precondition** and it **fixed no latent bug**. (Its "six half-converted guards" were bugs my own regex introduced and then repaired.) A correction is posted on that PR so its commit message doesn't mislead the next reader.

**The real hazard was the factory, not the instance** — same class of breakage, wrong name.

## Ordering

Unchanged. Classic-`defer` and non-async `type="module"` share **one** post-parse execution queue, in document order, so highway.js keeps its position at `index.html:1244`.

## Verification

A/B against `origin/main` — **15 probes identical, zero page errors**: `window.highway`, `window.createHighway`, the full API surface, a real song playing, the chart clock advancing, and the seek → `setTime` sync.

**The perf gate passes at 1.85ms** against its 12ms budget (module evaluation costs nothing at render time) — which is exactly what #910 was built to tell me.

node **1045** · pytest **2416** · ESLint **0** · Codex **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)