### PR TITLE
tuningMidis follow-ups: NaN/Inf guard in freqs_to_midis + v3 badge adopts exact midis

### DIFF
--- a/lib/tunings.py
+++ b/lib/tunings.py
@@ -101,14 +101,16 @@ def open_midis_to_freqs(midis: list[int], reference_pitch: float = DEFAULT_REFER
 def freqs_to_midis(freqs: list[float], reference_pitch: float = DEFAULT_REFERENCE_PITCH) -> list[int] | None:
     """Return absolute open-string MIDI notes for frequencies at the supplied
     A4 reference — the inverse of open_midis_to_freqs. None if any entry is
-    non-numeric or non-positive (a provider could hand us anything)."""
+    non-numeric, non-finite, or non-positive (a provider could hand us
+    anything; NaN/Infinity would otherwise raise inside int(round(...)) and
+    500 the /api/tunings endpoint)."""
     out: list[int] = []
     for f in freqs:
         try:
             f = float(f)
         except (TypeError, ValueError):
             return None
-        if f <= 0:
+        if not math.isfinite(f) or f <= 0:
             return None
         out.append(int(round(69 + 12 * math.log2(f / reference_pitch))))
     return out

--- a/static/v3/badges.js
+++ b/static/v3/badges.js
@@ -120,11 +120,20 @@
             if (!r.ok) return;
             const data = await r.json();
             _tuningsByKey = data.tunings || {};
-            // Build TUNING_NOTE from the first (lowest) string frequency of each tuning.
+            // Build TUNING_NOTE from the lowest string of each tuning. Prefer the
+            // exact integer midis the server now sends (tuningMidis, #829) — the
+            // frequency path reconstructs the note via log2 against a hardcoded
+            // 440 and can land a semitone off at non-440 reference pitches.
+            // Frequencies remain the fallback for older cached responses.
+            const midisByKey = data.tuningMidis || {};
             TUNING_NOTE = {};
             for (const key of Object.keys(_tuningsByKey)) {
                 for (const [name, freqs] of Object.entries(_tuningsByKey[key])) {
-                    if (!(name in TUNING_NOTE) && Array.isArray(freqs) && freqs.length > 0) {
+                    if (name in TUNING_NOTE) continue;
+                    const midis = midisByKey[key] && midisByKey[key][name];
+                    if (Array.isArray(midis) && midis.length > 0 && Number.isFinite(midis[0])) {
+                        TUNING_NOTE[name] = NOTE_NAMES[((midis[0] % 12) + 12) % 12];
+                    } else if (Array.isArray(freqs) && freqs.length > 0) {
                         TUNING_NOTE[name] = _freqToNote(freqs[0]);
                     }
                 }

--- a/tests/test_tunings.py
+++ b/tests/test_tunings.py
@@ -275,4 +275,7 @@ def test_freqs_to_midis_rejects_garbage():
     from tunings import freqs_to_midis
     assert freqs_to_midis([82.41, 0]) is None          # non-positive
     assert freqs_to_midis([82.41, "x"]) is None        # non-numeric
+    assert freqs_to_midis([float("nan")]) is None      # non-finite (would raise in int(round(...)))
+    assert freqs_to_midis([float("inf")]) is None      # non-finite
+    assert freqs_to_midis([float("-inf")]) is None     # non-finite
     assert freqs_to_midis([]) == []                    # vacuously fine


### PR DESCRIPTION
Two small follow-ups to #829:

1. **Crash guard.** `freqs_to_midis` now rejects non-finite frequencies (NaN/Infinity) — a tuning provider handing one through would otherwise raise inside `int(round(...))` and 500 `GET /api/tunings`. This closes CodeRabbit's review nit on #829. Tests: `nan`/`inf`/`-inf` alongside the existing garbage cases (`tests/test_tunings.py` 50/50 green).

2. **Consumer adoption.** The v3 instrument badge's `TUNING_NOTE` now prefers the exact integer midis the server serves (`tuningMidis`) over reconstructing the note name from the lowest string's frequency via `log2` against a hardcoded 440 — which can land a semitone off at non-440 reference pitches. The frequency path stays as fallback for older cached responses. (This is the adoption the #829 body promised; Virtuoso made the same switch plugin-side.)

ESLint clean on `badges.js`; `working_tuning`/`badges_handedness`/`tuning_display` node tests 26/26 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MS2YFb6UUSwJVV6CmEa25i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid tuning frequencies, including NaN and infinite values, are now rejected consistently.
  * Tuning badges now display note names using server-provided MIDI values when available, improving accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->