### PR TITLE
feat(v3): add desktop-only "Start in fullscreen" system option

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -218,6 +218,7 @@ import {
     setAvOffsetMs,
     setInstrumentPathway,
     setupAppUpdates,
+    setupWindowOptions,
     syncDefaultArrangementPin,
 } from './js/settings.js';
 import {

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -100,6 +100,7 @@ export async function loadSettings() {
     // failed fetch below still leaves the desktop updater wired up.
     // setupAppUpdates() is idempotent via _appUpdatesWired.
     setupAppUpdates();
+    setupWindowOptions();
     const resp = await fetch('/api/settings');
     const data = await resp.json();
     // Null-guard the form fields: on the v3 tabbed settings page the markup is
@@ -165,6 +166,47 @@ export async function loadSettings() {
     // Hydrate the highway-color settings UI (theme select + per-string pickers)
     // — the runtime apply path (initHighwayColors) doesn't render these controls.
     hwcInitSettingsUI();
+}
+
+// ── Window options (desktop-only) ────────────────────────────────────────
+// Desktop-only window preferences (start-in-fullscreen, …). The whole block
+// stays hidden in the plain web / Docker app; unhide + wire only when the
+// feedBack-desktop bridge (window.feedBackDesktop.window) exposes the getter
+// and setter. Persistence lives desktop-side because only the Electron main
+// process can read the pref at window-creation time — core just proxies.
+export let _windowOptionsWired = false;
+
+export function setupWindowOptions() {
+    const block = document.getElementById('window-options-block');
+    if (!block) return;
+    const winApi = window.feedBackDesktop?.window;
+    // Per-method capability check: a partial/older bridge may expose `window`
+    // without this shape. Leave the block hidden rather than half-wiring it.
+    if (!winApi
+        || typeof winApi.getStartFullscreen !== 'function'
+        || typeof winApi.setStartFullscreen !== 'function') {
+        return;
+    }
+
+    block.classList.remove('hidden');
+
+    const cb = document.getElementById('setting-start-fullscreen');
+    if (!cb) return;
+
+    // Hydrate from the desktop-persisted value. The getter may be sync or
+    // async (IPC round-trip); Promise.resolve normalises both.
+    Promise.resolve(winApi.getStartFullscreen()).then(function (on) {
+        cb.checked = !!on;
+    }).catch(function () { /* leave unchecked on error */ });
+
+    // Guard only the listener against double-binding; unhide + re-hydrate
+    // stay idempotent so re-entering Settings refreshes the checkbox.
+    if (!_windowOptionsWired) {
+        _windowOptionsWired = true;
+        cb.addEventListener('change', function () {
+            try { winApi.setStartFullscreen(cb.checked); } catch (_) { /* best-effort */ }
+        });
+    }
 }
 
 export const APP_UPDATE_CHANNELS = ['stable', 'rc', 'beta', 'alpha'];

--- a/static/v3/index.html
+++ b/static/v3/index.html
@@ -757,8 +757,8 @@
                     <div id="window-options-block" class="hidden">
                         <div class="fb-srow">
                             <div class="fb-srow-main">
-                                <div class="fb-srow-title">Start in fullscreen</div>
-                                <div class="fb-srow-desc">Launch the desktop app in fullscreen every time.</div>
+                                <div class="fb-srow-title">Fullscreen</div>
+                                <div class="fb-srow-desc">Run fee[dB]ack in fullscreen mode. On macOS, changes take effect on the next launch.</div>
                             </div>
                             <div class="fb-srow-control">
                                 <label class="fb-switch">

--- a/static/v3/index.html
+++ b/static/v3/index.html
@@ -753,6 +753,21 @@
                             <a href="https://github.com/got-feedback/feedback-desktop/releases" target="_blank" rel="noopener" class="text-accent hover:text-accent-light underline">download new versions from GitHub Releases</a>.
                         </p>
                     </div>
+                    <!-- Window options — desktop-only; setupWindowOptions() unhides. -->
+                    <div id="window-options-block" class="hidden">
+                        <div class="fb-srow">
+                            <div class="fb-srow-main">
+                                <div class="fb-srow-title">Start in fullscreen</div>
+                                <div class="fb-srow-desc">Launch the desktop app in fullscreen every time.</div>
+                            </div>
+                            <div class="fb-srow-control">
+                                <label class="fb-switch">
+                                    <input type="checkbox" id="setting-start-fullscreen">
+                                    <span class="fb-switch-track"></span>
+                                </label>
+                            </div>
+                        </div>
+                    </div>
                     <!-- Library folder path -->
                     <div class="fb-srow fb-srow-stack">
                         <div class="fb-srow-main">


### PR DESCRIPTION
## What

Adds a **Start in fullscreen** toggle to Settings → System (between App updates and Library folder path).

Addresses the desktop request in got-feedback/feedBack-desktop#97 — users want the app to launch fullscreen without pressing the OS hotkey (⌃⌘F) every time.

## How it stays desktop-only

The block ships `hidden` and is gated exactly like the existing App-updates block. `setupWindowOptions()` (in `static/js/settings.js`, called from `loadSettings()`) only unhides + wires it when the feedBack-desktop bridge exposes:

```js
window.feedBackDesktop.window.{ getStartFullscreen, setStartFullscreen }
```

- Web / Docker builds have no `feedBackDesktop` bridge → the function returns early → the section never appears.
- It's a **per-method capability check**, so even on desktop it stays hidden until the bridge actually ships those methods — no half-wired toggle.

Persistence lives desktop-side because only the Electron main process can read the pref at window-creation time; core just proxies through the bridge (getter normalised via `Promise.resolve` to allow sync or async IPC).

## Scope

Core UI + bridge proxy only. The desktop bridge (`feedBackDesktop.window`) and the actual launch-in-fullscreen behaviour land in a follow-up **feedBack-desktop** PR. Until then this is inert in every shipping build.

## Testing

- Web/Docker: `#window-options-block` is present in the DOM but `display:none` (no bridge) — nothing new renders. Manually `classList.remove('hidden')` in devtools confirms the row layout.
- No new Tailwind utilities (all classes pre-existing), so no `tailwind.min.css` rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a desktop-only **Window options** section in Settings.
  * Added a **Start in fullscreen** option that reflects and saves the selected preference.
  * The option stays hidden when desktop window controls aren’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->