### PR TITLE
test(stats): prove seconds-only recency on a fresh row

### DIFF
--- a/tests/test_song_stats_api.py
+++ b/tests/test_song_stats_api.py
@@ -480,8 +480,11 @@ def test_seconds_only_post_accrues_without_touching_position(client):
     # overwrite Continue with the end-of-song offset).
     assert row["plays"] == 0
     assert row["last_position"] == pytest.approx(42.0)
-    # But the song WAS played — recency ordering must see it.
-    assert row["last_played_at"]
+    # Recency must come from the seconds-only POST itself — prove it on a
+    # FRESH row (the position touch above already stamps last_played_at,
+    # which would make an assertion here vacuous).
+    r2 = client.post("/api/stats", json={"filename": "fresh.archive", "seconds": 30})
+    assert r2.json()["stats"]["last_played_at"]
     # Still counts as playing today for the streak.
     assert r.json()["progress"]["current_streak"] == 1
 


### PR DESCRIPTION
CodeRabbit on #947 (thread replied+resolved): the prior `lastPlayPosition` POST already stamped `last_played_at`, so the recency assertion passed even if the seconds-only path left it unchanged — a guard that cannot fail. Now asserted on a fresh row. Codex preflight clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for seconds-only song updates.
  * Verified that newly created songs receive a `last_played_at` timestamp when playback position is submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->