### PR TITLE
test(career): assert exact arena manifest mappings

### DIFF
--- a/tests/js/career_plugin.test.js
+++ b/tests/js/career_plugin.test.js
@@ -55,8 +55,12 @@ test('arena venue pack ships with full media in the plugin checkout', () => {
     const packDir = path.join(PLUGIN_DIR, 'venue-packs', 'arena');
     const manifest = JSON.parse(fs.readFileSync(path.join(packDir, 'manifest.json'), 'utf8'));
     assert.equal(manifest.venue, 'arena');
-    assert.deepEqual(Object.keys(manifest.loops).sort(),
-        ['bored', 'ecstatic', 'engaged', 'neutral']);
+    assert.deepEqual(manifest.loops, {
+        bored: 'bored.mp4', neutral: 'neutral.mp4',
+        engaged: 'engaged.mp4', ecstatic: 'ecstatic.mp4',
+    });
+    assert.deepEqual(manifest.stingers, { clap: 'clap.mp4', cheer: 'cheer.mp4' });
+    assert.deepEqual(manifest.sfx, { up: 'sfx-up.mp3', down: 'sfx-down.mp3' });
     assert.equal(manifest.intro.video, 'intro.mp4');
     assert.equal(manifest.intro.audio, 'arena-ambience.mp3');
     for (const f of [


### PR DESCRIPTION
CodeRabbit follow-up on #961 — assert the complete `loops`/`stingers`/`sfx` objects instead of key/presence checks, so swapped media filenames fail the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened validation of arena venue media manifests, including loop, stinger, and sound-effect filename mappings.
  * Continued verifying that all declared media files exist and contain data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->