### PR TITLE
feat(highway_3d): fret wires flash on a confirmed hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   survives only as the fallback on anchor-less charts). At most **two wires are ever lit at
   once**: when overlapping decay tails (fast passages) would light a run of wires, the
   flash collapses to the outermost pair of the lit span — one bracket, never a picket
-  fence. With no scorer attached, nothing changes.
+  fence. The gem's rim joins in: on a confirmed hit the outline flashes in the
+  string's own colour with the same intensity treatment as the wires, fading with the
+  scorer's alpha. With no scorer attached, nothing changes.
 
 ### Changed
 - **`GET /api/song/{f}?stems=1`** (new, opt-in) — returns the pack's playable stem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   data-driven bar (avg ≥ 75%) — into the career state; abandoned sets never
   log (no fail state: the gig you finished is the gig you played). Passports
   carry their gig log; instruments their gig count.
+- **3D Highway: fret wires flash on a confirmed hit** — when a scorer (note_detect)
+  confirms a note through the `getNoteState` provider (feedBack#254), the fret wires
+  bracketing it light up. A fretted note lights the wire behind it and the wire it's
+  pressed against; a chord lights only the outermost wires of its shape; an open
+  string lights the anchor lane's edge wires (its gem is drawn as a slab spanning the
+  lane, so those are the wires it sits between). With no scorer attached, nothing
+  changes.
 
 ### Changed
 - **Folder library renders only the songs on screen** (#965) — a song list used to
@@ -54,6 +61,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tree — which is how the song-preview menu check ended up eating ~50% of the
   renderer and dropping the app to 2.7 fps. Lists longer than 200 songs are now
   windowed (25–31 rows in the DOM instead of 50,000); shorter lists are unchanged.
+- **3D Highway: fret wires read as a focus cue** — the contrast between the active
+  anchor lane and the rest of the neck is widened (the lane's wires brighter, the rest
+  dimmer), and the wires themselves are slightly thicker.
 - **The full mix is a stem** (#933) — core no longer depends on `original_audio:`, a
   top-level manifest key this repo invented (#583) that the feedpak spec never had.
   The format already carried the pre-separation mixdown as a stem; feedpak 1.15.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,11 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   survives only as the fallback on anchor-less charts). At most **two wires are ever lit at
   once**: when overlapping decay tails (fast passages) would light a run of wires, the
   flash collapses to the outermost pair of the lit span — one bracket, never a picket
-  fence. The flash itself is a one-shot "lightning strike": a near-instant crack up, a
-  fast shocked fall with an electric flicker biting into it, then hard dark. Strikes are
-  **one per judged hit**: each correct note is its own strike (consecutive correct notes
-  on the same fret strike twice), a strummed chord strikes once as a unit, and a held
-  sustain strikes only at the moment it's hit — the wires go out while the note rings on. The gem's rim joins in: on a confirmed hit the outline flashes in the
+  fence. The gem's rim joins in: on a confirmed hit the outline flashes in the
   string's own colour with the same intensity treatment as the wires, fading with the
   scorer's alpha. With no scorer attached, nothing changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   survives only as the fallback on anchor-less charts). At most **two wires are ever lit at
   once**: when overlapping decay tails (fast passages) would light a run of wires, the
   flash collapses to the outermost pair of the lit span — one bracket, never a picket
-  fence. The gem's rim joins in: on a confirmed hit the outline flashes in the
+  fence. The flash itself is a one-shot "lightning strike": a near-instant crack up, a
+  fast shocked fall with an electric flicker biting into it, then hard dark — a held
+  sustain triggers exactly one strike and the wires go out while the note rings on. The gem's rim joins in: on a confirmed hit the outline flashes in the
   string's own colour with the same intensity treatment as the wires, fading with the
   scorer's alpha. With no scorer attached, nothing changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bracketing it light up. A fretted note lights the wire behind it and the wire it's
   pressed against; a chord lights only the outermost wires of its shape; an open
   string lights the anchor lane's edge wires (its gem is drawn as a slab spanning the
-  lane, so those are the wires it sits between). At most **two wires are ever lit at
+  lane, so those are the wires it sits between); a chord likewise lights the lane's edge
+  wires — the lit lane strip can run a fret past the chord's outermost fret, and a
+  bracket one wire inside the lit lane reads as misaligned (the shape's own outer pair
+  survives only as the fallback on anchor-less charts). At most **two wires are ever lit at
   once**: when overlapping decay tails (fast passages) would light a run of wires, the
   flash collapses to the outermost pair of the lit span — one bracket, never a picket
   fence. With no scorer attached, nothing changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,8 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bracketing it light up. A fretted note lights the wire behind it and the wire it's
   pressed against; a chord lights only the outermost wires of its shape; an open
   string lights the anchor lane's edge wires (its gem is drawn as a slab spanning the
-  lane, so those are the wires it sits between). With no scorer attached, nothing
-  changes.
+  lane, so those are the wires it sits between). At most **two wires are ever lit at
+  once**: when overlapping decay tails (fast passages) would light a run of wires, the
+  flash collapses to the outermost pair of the lit span — one bracket, never a picket
+  fence. With no scorer attached, nothing changes.
 
 ### Changed
 - **`GET /api/song/{f}?stems=1`** (new, opt-in) — returns the pack's playable stem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   once**: when overlapping decay tails (fast passages) would light a run of wires, the
   flash collapses to the outermost pair of the lit span — one bracket, never a picket
   fence. The flash itself is a one-shot "lightning strike": a near-instant crack up, a
-  fast shocked fall with an electric flicker biting into it, then hard dark — a held
-  sustain triggers exactly one strike and the wires go out while the note rings on. The gem's rim joins in: on a confirmed hit the outline flashes in the
+  fast shocked fall with an electric flicker biting into it, then hard dark. Strikes are
+  **one per judged hit**: each correct note is its own strike (consecutive correct notes
+  on the same fret strike twice), a strummed chord strikes once as a unit, and a held
+  sustain strikes only at the moment it's hit — the wires go out while the note rings on. The gem's rim joins in: on a confirmed hit the outline flashes in the
   string's own colour with the same intensity treatment as the wires, fading with the
   scorer's alpha. With no scorer attached, nothing changes.
 

--- a/plugins/highway_3d/plugin.json
+++ b/plugins/highway_3d/plugin.json
@@ -1,7 +1,7 @@
 {
     "id": "highway_3d",
     "name": "3D Highway",
-    "version": "3.31.5",
+    "version": "3.32.0",
     "type": "visualization",
     "bundled": true,
     "script": "screen.js",

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -882,9 +882,12 @@
     // frets reads as wrapping a cylindrical neck — chart-format depth cue.
     // Negative Z = away from camera (into the highway). All tunable.
     const FRET_BOW_DZ = -1.2 * K;        // middle-of-span Z offset
-    const FRET_TUBE_RADIUS = STR_THICK * 0.55; // ~matches old box thickness
+    const FRET_TUBE_RADIUS = STR_THICK * 0.75; // slightly thicker than a string
     const FRET_TUBE_SEG = 12;            // tubular segments along the curve
-    const FRET_TUBE_RADIAL = 6;          // radial segments (cross-section)
+    // Radial segments (cross-section). 8 rather than 6: at FRET_TUBE_RADIUS the
+    // hexagonal facets of a 6-segment tube are visible along the top highlight.
+    // One shared geometry for all frets, so the extra segments are ~free.
+    const FRET_TUBE_RADIAL = 8;
     // metalness kept moderate, NOT ~1.0: MeshStandardMaterial is PBR and the
     // scene has no envMap, so a full-metal fret would reflect black and render
     // dark (the nut/headstock use metalness 0.02 for the same reason). At ~0.4
@@ -894,6 +897,31 @@
     const FRET_METALNESS = 0.4;          // lit steel / brass when gold
     const FRET_ROUGHNESS = 0.3;
     const FRET_EMISSIVE = 0x12141a;      // cool dim floor, never fully black
+
+    // Fret-wire tiers. Wires inside the active anchor lane (the frets the player
+    // is actually reading) sit bright; everything outside recedes. Kept far
+    // apart on purpose — a narrow gap reads as noise rather than as a focus cue.
+    const FRET_WIRE_ACTIVE_HEX = 0xD8A636; // gold; numeric twin of FRET_LABEL_GOLD_HEX
+    const FRET_WIRE_ACTIVE_OP = 0.9;
+    const FRET_WIRE_IDLE_HEX = 0x4A4A60;
+    const FRET_WIRE_IDLE_OP = 0.28;
+
+    // Hit flash: when a scorer (feedBack#254) confirms a note, the two wires
+    // bracketing its fret (f-1 and f) flash bright. Emissive is boosted as well
+    // as albedo — a MeshStandard fret with no envMap barely brightens from
+    // albedo alone, so without the emissive lift the "flash" reads as a shrug.
+    const FRET_WIRE_HIT_HEX = 0xFFFFFF;      // blown out to white at full flash
+    const FRET_WIRE_HIT_EMISSIVE = 0xFFE9B0; // hot warm-white glow
+    const FRET_WIRE_HIT_OP = 1.0;
+    // Emissive multiplier at full flash (baseline is 1). Pushing emissive past
+    // 1.0 is what actually makes the wire read as a light source rather than a
+    // brightly-lit object — the color alone saturates and stops there.
+    const FRET_WIRE_HIT_INTENSITY = 4.2;
+    // Seconds for a flash to fall to ~1/e once the provider stops reporting.
+    // The provider already fades its own `alpha` on a struck note; this tail
+    // just keeps the hand-off from popping, and smooths the frame-to-frame
+    // jitter of a held sustain (whose alpha tracks live input level).
+    const FRET_WIRE_HIT_DECAY = 0.32;
 
     const S_BASE = 3 * K;
     const S_GAP = 4 * K;
@@ -4030,6 +4058,10 @@
         let _drawRecentByString = null;
         /** Snapshotted in update() — drawNote() is a sibling of update(), not nested in its closure. */
         let _drawChordTemplates = null;
+        /** Ditto — drawNote() needs the anchors to resolve the lane's outer
+         * wires for an open note's hit flash (an open note has no fret of its
+         * own; its slab spans the lane, so the lane edges are what bracket it). */
+        let _drawAnchors = null;
         /** Teaching marks sd/ch overlay pref (§6.2.2), mirrored from the 2D
          * highway's `teachingMarksVisible` bundle flag. */
         let _drawTeachingMarks = false;
@@ -4744,6 +4776,21 @@
         const _scrStringSustain      = new Array(MAX_RENDER_STRINGS).fill(false);
         const _scrStringAnticipation = new Array(MAX_RENDER_STRINGS).fill(0);
         const _scrFretHeat           = new Array(NFRETS + 1).fill(0);
+        // Fret-wire hit flash. _fwHitIn is per-frame (cleared with the rest of
+        // the frame state, written by drawNote when a provider confirms a note);
+        // _fwHitGlow persists across frames so the flash can decay smoothly
+        // rather than snapping off the frame the provider goes quiet.
+        const _fwHitIn               = new Float32Array(NFRETS + 1);
+        const _fwHitGlow             = new Float32Array(NFRETS + 1);
+        // Per-frame chord accumulator. A chord flashes only the OUTERMOST wires
+        // of its shape, but drawNote() sees one chord note at a time and can't
+        // know the span — so hits accumulate here keyed by chord, and the flash
+        // pass (which runs after every draw loop) resolves min/max into wires.
+        // Typically 0-2 entries: only chords with a confirmed hit land here.
+        const _fwChordAcc            = new Map();
+        let _fwHitPrevTime = -Infinity; // chart time of the last decay step
+        let _fwHitColor = null;         // T.Color scratch (built in initScene)
+        let _fwHitEmissive = null;
         const _scrStrGlow            = new Array(MAX_RENDER_STRINGS).fill(0.5);
         const _scrAccentFillBoost    = new Array(MAX_RENDER_STRINGS).fill(0);
         const _scrNextNoteByString   = new Array(MAX_RENDER_STRINGS).fill(null);
@@ -6883,6 +6930,10 @@
                 transparent: true, opacity: 1.0, depthWrite: false,
             }));
             _laneTargetColor = new T.Color(0x4488ff);
+            _fwHitColor = new T.Color(FRET_WIRE_HIT_HEX);
+            _fwHitEmissive = new T.Color(FRET_WIRE_HIT_EMISSIVE);
+            _fwHitGlow.fill(0);
+            _fwHitPrevTime = -Infinity;
             mSus = activePalette.map(c => new T.MeshLambertMaterial({
                 color: c, transparent: true, opacity: 0.35,
             }));
@@ -8971,9 +9022,11 @@
             // reads as brass. depthTest:false: string BoxGeometry (MeshStandard,
             // depthWrite:true) writes depth at Z=+STR_THICK/2; wires near Z=0
             // would fail the depth test at string pixels despite higher layer.
-            // Colors are updated each frame by the fretWireMats loop in update():
-            //   default  → gray  0x666688, opacity 0.4
-            //   in-anchor→ gold  0xD8A636, opacity 0.8  (same as FRET_LABEL_GOLD_HEX)
+            // Colors are updated each frame by the fretWireMats loop in update(),
+            // which drives every wire to one of two tiers: FRET_WIRE_IDLE_* by
+            // default, FRET_WIRE_ACTIVE_* inside the anchor lane. The material is
+            // created at the idle tier so frame 0 (before update() first runs)
+            // already matches.
             const yTop = Math.max(sY(0), sY(nStr - 1));
             const yBottom = Math.min(sY(0), sY(nStr - 1));
             const wireH = (yTop + S_GAP * 0.3) - (yBottom - S_GAP * 0.3);
@@ -8995,12 +9048,12 @@
             for (let f = 0; f <= NFRETS; f++) {
                 const x = xFret(f);
                 const mat = new T.MeshStandardMaterial({
-                    color: 0x666688, metalness: FRET_METALNESS, roughness: FRET_ROUGHNESS,
+                    color: FRET_WIRE_IDLE_HEX, metalness: FRET_METALNESS, roughness: FRET_ROUGHNESS,
                     emissive: FRET_EMISSIVE,
                     // depthWrite:false (matches other transparent overlays here):
                     // a transparent fret must not write depth or it can occlude
                     // later-drawn transparent elements despite depthTest:false.
-                    transparent: true, opacity: 0.4, depthTest: false, depthWrite: false,
+                    transparent: true, opacity: FRET_WIRE_IDLE_OP, depthTest: false, depthWrite: false,
                 });
                 const fw = new T.Mesh(fretTubeGeo, mat);
                 fw.position.set(x, wireMidY, 0);
@@ -10641,12 +10694,17 @@
                     const _m = fretWireMats[_f];
                     if (!_m) continue;
                     if (_fwMin >= 0 && _f >= _fwMin && _f <= _fwMax) {
-                        _m.color.setHex(0xD8A636);
-                        _m.opacity = 0.8;
+                        _m.color.setHex(FRET_WIRE_ACTIVE_HEX);
+                        _m.opacity = FRET_WIRE_ACTIVE_OP;
                     } else {
-                        _m.color.setHex(0x666688);
-                        _m.opacity = 0.4;
+                        _m.color.setHex(FRET_WIRE_IDLE_HEX);
+                        _m.opacity = FRET_WIRE_IDLE_OP;
                     }
+                    // Baseline emissive every frame: the hit-flash pass below
+                    // lerps these toward FRET_WIRE_HIT_* in place, so they must
+                    // be re-seeded or a flash would never fade back out.
+                    _m.emissive.setHex(FRET_EMISSIVE);
+                    _m.emissiveIntensity = 1;
                 }
             }
 
@@ -10679,6 +10737,8 @@
             _scrStringSustain.fill(false, 0, nStr);
             _scrStringAnticipation.fill(0, 0, nStr);
             _scrFretHeat.fill(0);           // always NFRETS+1, cheap flat fill
+            _fwHitIn.fill(0);               // this frame's confirmed-hit frets
+            _fwChordAcc.clear();
             _scrStrGlow.fill(0.5, 0, nStr);
             _scrAccentFillBoost.fill(0, 0, nStr);
             const noteState = {
@@ -10793,6 +10853,7 @@
 
             _drawNextByString = nextNoteByString;
             _drawChordTemplates = bundle.chordTemplates ?? null;
+            _drawAnchors = anchors ?? null;
             _drawTeachingMarks = !!bundle.teachingMarksVisible;
             // Default on: only an explicit false (older bundles omit the flag) hides fg.
             _showFingerHints = bundle.fingerHintsVisible !== false;
@@ -12581,6 +12642,57 @@
                 ? arpeggioLaneDividerXYScaleMatchFrameRim(arpLaneRimAccentMul)
                 : 1;
 
+            // ── Fret-wire hit flash (apply) ───────────────────────────────
+            // Runs here, after the note + chord draw loops, so it sees this
+            // frame's verdicts (_fwHitIn) rather than the previous frame's —
+            // the base tier loop that seeds color/opacity/emissive sits far
+            // above, before any note has been drawn.
+            //
+            // _fwHitGlow decays exponentially in CHART time, so the tail is
+            // frame-rate independent and honours playback speed. Seeking
+            // backward resets it — otherwise a flash from a hit we jumped away
+            // from would linger on the wire.
+            if (fretWireMats.length && _fwHitColor) {
+                // Resolve accumulated chord hits: a chord flashes ONLY the wire
+                // behind its lowest fret and the wire at its highest, so the
+                // shape reads as one bracketed block rather than a picket fence
+                // of every wire in between. Open strings within the chord light
+                // the lane edges (they have no fret to bracket).
+                for (const _fwE of _fwChordAcc.values()) {
+                    if (_fwE.maxF >= _fwE.minF && _fwE.a > 0) {
+                        const _w0 = Math.max(0, _fwE.minF - 1);
+                        const _w1 = Math.min(NFRETS, _fwE.maxF);
+                        if (_fwE.a > _fwHitIn[_w0]) _fwHitIn[_w0] = _fwE.a;
+                        if (_fwE.a > _fwHitIn[_w1]) _fwHitIn[_w1] = _fwE.a;
+                    }
+                    if (_fwE.openA > 0) {
+                        const _fwB = anchorLaneBoundsAt(_drawAnchors, _fwE.t);
+                        if (_fwB) {
+                            if (_fwE.openA > _fwHitIn[_fwB.dMin]) _fwHitIn[_fwB.dMin] = _fwE.openA;
+                            if (_fwE.openA > _fwHitIn[_fwB.dMax]) _fwHitIn[_fwB.dMax] = _fwE.openA;
+                        }
+                    }
+                }
+
+                const _fwDt = now - _fwHitPrevTime;
+                if (!(_fwDt >= 0) || _fwDt > 1) _fwHitGlow.fill(0); // first frame, seek, or long stall
+                const _fwDecay = (_fwDt > 0 && _fwDt <= 1)
+                    ? Math.exp(-_fwDt / FRET_WIRE_HIT_DECAY)
+                    : 0;
+                _fwHitPrevTime = now;
+                for (let _f = 0; _f <= NFRETS; _f++) {
+                    const _g = Math.max(_fwHitIn[_f], _fwHitGlow[_f] * _fwDecay);
+                    _fwHitGlow[_f] = _g;
+                    if (_g < 0.004) continue;   // below perceptible — skip the lerps
+                    const _m = fretWireMats[_f];
+                    if (!_m) continue;
+                    _m.color.lerp(_fwHitColor, _g);
+                    _m.emissive.lerp(_fwHitEmissive, _g);
+                    _m.emissiveIntensity = 1 + (FRET_WIRE_HIT_INTENSITY - 1) * _g;
+                    _m.opacity += (FRET_WIRE_HIT_OP - _m.opacity) * _g;
+                }
+            }
+
             // ── Dynamic highway lane ──────────────────────────────────────
             // Chart <anchor> tags drive the lane whenever they exist — do not
             // require nearby notes (activeFrets) or camera-driven activity.
@@ -13762,6 +13874,59 @@
             const _showHit = (_ndState === 'miss') ? false
                 : (_ndState ? _ndGood
                 : (hit || (n.f > 0 && inGhostWin)));
+
+            // ── Fret-wire hit flash ───────────────────────────────────────
+            // A confirmed note lights the wires that bracket it:
+            //   single, fretted (f > 0) → the wire behind it (f-1) and the wire
+            //           it's pressed against (f).
+            //   open (f = 0)  → the OUTER wires of the anchor lane. An open
+            //           string has no fret of its own, and its gem is drawn as a
+            //           wide slab spanning the lane (see xBase /
+            //           openNoteLaneBoxW), so the lane's edge wires are exactly
+            //           what the slab sits between — the same relationship a
+            //           fretted note has to its own two wires.
+            //   chord   → only the OUTERMOST wires of the whole shape, not every
+            //           wire it spans. drawNote() is the chord loop's per-note
+            //           call, so it can't see the span from here: chord hits
+            //           accumulate into _fwChordAcc and the flash pass resolves
+            //           min/max fret → outer wires once the loop has finished.
+            // Gated on _ndGood, not _showHit: only a scorer's verdict counts,
+            // never the proximity heuristic that merely means "near the line".
+            if (_ndGood) {
+                const _fwA = (_ndCsIsObj && _ndCs && typeof _ndCs.alpha === 'number')
+                    ? Math.max(0, Math.min(1, _ndCs.alpha))
+                    : 1;
+                if (fromChord) {
+                    // ch.id can be absent (pitfall #8) — fall back to the chord's
+                    // time, which is what n.t already carries for a chord note.
+                    const _fwK = (chordId !== undefined && chordId !== null) ? chordId : `t${n.t}`;
+                    let _fwE = _fwChordAcc.get(_fwK);
+                    if (!_fwE) {
+                        _fwE = { minF: Infinity, maxF: -Infinity, a: 0, openA: 0, t: n.t };
+                        _fwChordAcc.set(_fwK, _fwE);
+                    }
+                    if (n.f > 0 && n.f <= NFRETS) {
+                        if (_fwA > _fwE.a) _fwE.a = _fwA;
+                        if (n.f < _fwE.minF) _fwE.minF = n.f;
+                        if (n.f > _fwE.maxF) _fwE.maxF = n.f;
+                    } else if (n.f === 0 && _fwA > _fwE.openA) {
+                        _fwE.openA = _fwA;   // open strings in the chord → lane edges
+                    }
+                } else if (n.f > 0 && n.f <= NFRETS) {
+                    if (_fwA > _fwHitIn[n.f - 1]) _fwHitIn[n.f - 1] = _fwA;
+                    if (_fwA > _fwHitIn[n.f]) _fwHitIn[n.f] = _fwA;
+                } else if (n.f === 0) {
+                    // Sampled at the note's own time, matching how the open
+                    // slab's width is derived (openNoteLaneBoxW(n.t)) — so the
+                    // flashed wires are the ones the slab is actually drawn
+                    // between, even if the lane has since moved.
+                    const _fwB = anchorLaneBoundsAt(_drawAnchors, n.t);
+                    if (_fwB) {
+                        if (_fwA > _fwHitIn[_fwB.dMin]) _fwHitIn[_fwB.dMin] = _fwA;
+                        if (_fwA > _fwHitIn[_fwB.dMax]) _fwHitIn[_fwB.dMax] = _fwA;
+                    }
+                }
+            }
 
             if (!effSkipBody && !arpGhostOnlyMode && !_overLinger) {
 
@@ -15235,7 +15400,12 @@
             _drawNextByString = null; _drawRecentByString = null;
             _susVerdictLatch.clear();
             _drawChordTemplates = null;
+            _drawAnchors = null;
             _laneTargetColor = null;
+            _fwHitColor = _fwHitEmissive = null;
+            _fwHitGlow.fill(0);
+            _fwChordAcc.clear();
+            _fwHitPrevTime = -Infinity;
             _renderScale = 1;
             mBeatM = mBeatQ = null;
             pNote = pNoteEdge = pSus = pSusOutline = pSusRibbon = pSusRibbonOl = pLbl = pBeat = pSec = null;

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -14062,7 +14062,10 @@
                         // (intensity applied per string in the flash pass).
                         _ndOutline = mRimFlash[s] ?? mHitBright[s] ?? mGlow[s];
                         _ndFaceMat = mHitBrightArrays[s] ?? null;
-                        if (_vAlpha > _rimFlashIn[s]) _rimFlashIn[s] = _vAlpha;
+                        // Clamp like the wire path does — a provider returning
+                        // alpha > 1 must not over-drive emissiveIntensity.
+                        const _rimA = Math.max(0, Math.min(1, _vAlpha));
+                        if (_rimA > _rimFlashIn[s]) _rimFlashIn[s] = _rimA;
                         _hitPunch = 1 + 0.22 * _hitFx * _vAlpha;   // #3 scale-punch (biggest at strike, eases)
                         if (_verdictMarks) { const _tc = _timingHex(_ndMatchedMark && _ndMatchedMark.timingState); _ndLabels.push({ x, y: y + NH * 1.7, z: noteZ + 0.02, labels: [{ text: '✓', color: '#' + _tc.toString(16).padStart(6, '0') }] }); }  // #6 + #5
                         if (_sparks && _hitFx > 0 && _vAlpha > 0.5) {

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -4036,6 +4036,13 @@
         // Built in initScene() after mGlow. Array share the same material
         // instances so outline and face fill always match exactly.
         let mHitBright = [], mHitBrightArrays = [];
+        // Gem-rim hit flash ("just the rims"): per-string materials that flash
+        // in the STRING'S OWN colour with the same intensity treatment as the
+        // fret wires (FRET_WIRE_HIT_INTENSITY ramp, provider-alpha fade). Shared
+        // per string, so the applied intensity is the per-frame MAX alpha across
+        // that string's flashing gems — same compromise mGlow already makes.
+        let mRimFlash = [];
+        const _rimFlashIn = new Float32Array(S_COL.length);
         // [verdict glow] Per-frame accumulation of the note-state provider's
         // alpha (note_detect drives this from the live input level for held
         // sustains, and as a time-fade for fresh strikes). Applied at the top of
@@ -7048,13 +7055,21 @@
                 transparent: true, opacity: 1.0, depthWrite: false,
             }));
             mHitBrightArrays = mHitBright.map(m => [m, m, m, m, mEdgeTransparent, mEdgeTransparent]);
+
+            // Rim flash: string-coloured, wire-fashion intensity. Colour and
+            // emissive both take the palette colour so the rim reads as the
+            // string lighting up, not as a white wash over it.
+            mRimFlash = activePalette.map((c) => new T.MeshLambertMaterial({
+                color: c, emissive: c, emissiveIntensity: 1,
+                transparent: true, opacity: 1.0, depthWrite: false,
+            }));
             // Readability (#2 / charrette): the note gems + their outlines punch THROUGH
             // the distance fog so upcoming notes stay legible as they render in at the
             // horizon. The board, lane, sustains and background scenery keep their
             // atmospheric fog — only the note-defining materials are exempted, so the
             // highway still reads as deep while the notes never dissolve into the haze.
             [mWhiteOutline, mMissOutline].forEach(m => { if (m) m.fog = false; });
-            [mStr, mGlow, mStrHitOutline, mHitBright].forEach(arr => arr && arr.forEach(m => { if (m) m.fog = false; }));
+            [mStr, mGlow, mStrHitOutline, mHitBright, mRimFlash].forEach(arr => arr && arr.forEach(m => { if (m) m.fog = false; }));
             // Outline materials render at a lower renderOrder than the body.
             // The body is rendered on top with opacity:1 on hit/miss, which
             // fully covers the outline center — only the fringe that extends
@@ -8365,6 +8380,10 @@
                     if (mStr[s].emissive) mStr[s].emissive.setHex(c);
                 }
                 if (mGlow[s]) mGlow[s].emissive.setHex(c);
+                if (mRimFlash[s]) {
+                    mRimFlash[s].color.setHex(c);
+                    mRimFlash[s].emissive.setHex(c);
+                }
                 if (mSus[s]) mSus[s].color.setHex(c);
                 if (mStrHitOutline[s]) {
                     mStrHitOutline[s].color.setHex(c);
@@ -10738,6 +10757,7 @@
             _scrStringAnticipation.fill(0, 0, nStr);
             _scrFretHeat.fill(0);           // always NFRETS+1, cheap flat fill
             _fwHitIn.fill(0);               // this frame's confirmed-hit frets
+            _rimFlashIn.fill(0);            // this frame's per-string rim-flash alphas
             _fwChordAcc.clear();
             _scrStrGlow.fill(0.5, 0, nStr);
             _scrAccentFillBoost.fill(0, 0, nStr);
@@ -12714,6 +12734,16 @@
                     _m.emissiveIntensity = 1 + (FRET_WIRE_HIT_INTENSITY - 1) * _g;
                     _m.opacity += (FRET_WIRE_HIT_OP - _m.opacity) * _g;
                 }
+
+                // Gem-rim flash: same intensity ramp as the wires, in the
+                // string's own colour. No decay tail of our own — the material
+                // is only ever ASSIGNED while the provider confirms the note,
+                // and the provider's alpha already fades; when it goes silent
+                // the outline reverts and idle intensity is irrelevant.
+                for (let _s = 0; _s < mRimFlash.length; _s++) {
+                    const _m = mRimFlash[_s];
+                    if (_m) _m.emissiveIntensity = 1 + (FRET_WIRE_HIT_INTENSITY - 1) * _rimFlashIn[_s];
+                }
             }
 
             // ── Dynamic highway lane ──────────────────────────────────────
@@ -14028,8 +14058,11 @@
                         _streakHits = 0;            // #7 break the streak (heat eases down)
                         if (_verdictMarks) _ndLabels.push({ x, y: y + NH * 1.7, z: noteZ + 0.02, labels: [{ text: '✗', color: '#ff5a7a' }] });  // #6
                     } else if (_ndGood) {
-                        _ndOutline = mHitBright[s] ?? mGlow[s];
+                        // Rim flashes in the string's own colour, wire-fashion
+                        // (intensity applied per string in the flash pass).
+                        _ndOutline = mRimFlash[s] ?? mHitBright[s] ?? mGlow[s];
                         _ndFaceMat = mHitBrightArrays[s] ?? null;
+                        if (_vAlpha > _rimFlashIn[s]) _rimFlashIn[s] = _vAlpha;
                         _hitPunch = 1 + 0.22 * _hitFx * _vAlpha;   // #3 scale-punch (biggest at strike, eases)
                         if (_verdictMarks) { const _tc = _timingHex(_ndMatchedMark && _ndMatchedMark.timingState); _ndLabels.push({ x, y: y + NH * 1.7, z: noteZ + 0.02, labels: [{ text: '✓', color: '#' + _tc.toString(16).padStart(6, '0') }] }); }  // #6 + #5
                         if (_sparks && _hitFx > 0 && _vAlpha > 0.5) {
@@ -15378,6 +15411,7 @@
             mHitSusOutline?.dispose?.();
             mEdgeTransparent?.dispose?.(); mEdgeTransparent = null;
             for (const m of mHitBright) m?.dispose?.(); mHitBright = []; mHitBrightArrays = [];
+            for (const m of mRimFlash) m?.dispose?.(); mRimFlash = [];
             for (const k in txtCache) {
                 const tm = txtCache[k];
                 tm.userData.h3dGhostFretMeshMat?.dispose?.();

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -921,7 +921,13 @@
     // The provider already fades its own `alpha` on a struck note; this tail
     // just keeps the hand-off from popping, and smooths the frame-to-frame
     // jitter of a held sustain (whose alpha tracks live input level).
-    const FRET_WIRE_HIT_DECAY = 0.32;
+    // The flash is a one-shot "lightning strike" pulse, not a lingering glow:
+    // a near-instant crack up, then a fast shocked fall with an electric
+    // flicker, then HARD ZERO — a held sustain does not keep the wires lit.
+    const FRET_WIRE_HIT_RISE = 0.025;         // s, the crack — near-instant fade-in
+    const FRET_WIRE_HIT_FALL = 0.16;          // s, the shock dying out; dark after
+    const FRET_WIRE_HIT_FLICKER_HZ = 26;      // shudder rate during the fall
+    const FRET_WIRE_HIT_FLICKER_DEPTH = 0.35; // how deep the shudder bites (0..1)
 
     const S_BASE = 3 * K;
     const S_GAP = 4 * K;
@@ -4784,11 +4790,18 @@
         const _scrStringAnticipation = new Array(MAX_RENDER_STRINGS).fill(0);
         const _scrFretHeat           = new Array(NFRETS + 1).fill(0);
         // Fret-wire hit flash. _fwHitIn is per-frame (cleared with the rest of
-        // the frame state, written by drawNote when a provider confirms a note);
-        // _fwHitGlow persists across frames so the flash can decay smoothly
-        // rather than snapping off the frame the provider goes quiet.
+        // the frame state, written by drawNote when a provider confirms a note).
+        // A RISING EDGE on it triggers a one-shot pulse: _fwPulseT0 records the
+        // strike's chart time, _fwPulseAmp its amplitude, _fwPrevIn detects the
+        // edge (a held 'active' verdict keeps the input high continuously, so a
+        // sustain triggers exactly one pulse — the wire goes dark while the
+        // note rings on). _fwHitGlow holds each wire's evaluated envelope value
+        // this frame, for the outer-pair selection below.
         const _fwHitIn               = new Float32Array(NFRETS + 1);
         const _fwHitGlow             = new Float32Array(NFRETS + 1);
+        const _fwPulseT0             = new Float32Array(NFRETS + 1).fill(-Infinity);
+        const _fwPulseAmp            = new Float32Array(NFRETS + 1);
+        const _fwPrevIn              = new Float32Array(NFRETS + 1);
         // Per-frame chord accumulator. A chord flashes only the OUTERMOST wires
         // of its shape, but drawNote() sees one chord note at a time and can't
         // know the span — so hits accumulate here keyed by chord, and the flash
@@ -12700,23 +12713,47 @@
                 }
 
                 const _fwDt = now - _fwHitPrevTime;
-                if (!(_fwDt >= 0) || _fwDt > 1) _fwHitGlow.fill(0); // first frame, seek, or long stall
-                const _fwDecay = (_fwDt > 0 && _fwDt <= 1)
-                    ? Math.exp(-_fwDt / FRET_WIRE_HIT_DECAY)
-                    : 0;
+                if (!(_fwDt >= 0) || _fwDt > 1) {   // first frame, seek, or long stall
+                    _fwHitGlow.fill(0);
+                    _fwPulseT0.fill(-Infinity);
+                    _fwPulseAmp.fill(0);
+                    _fwPrevIn.fill(0);
+                }
                 _fwHitPrevTime = now;
-                // Decay EVERY wire's glow state, but flash only the OUTERMOST
-                // pair of lit wires. Fast passages overlap their decay tails, so
-                // without this a run of consecutive notes lights a picket fence
-                // of wires at once; collapsing to the outer pair keeps the whole
-                // lit span reading as ONE bracket — the same rule chords already
-                // follow, applied across everything currently glowing. Interior
-                // wires keep decaying invisibly (the base tier loop re-seeds
-                // their materials each frame), so the bracket tightens naturally
-                // as outer tails expire.
+                // Evaluate every wire's pulse, but flash only the OUTERMOST pair
+                // of lit wires (one bracket, never a picket fence — the chord
+                // rule applied across everything currently pulsing). The pulse
+                // itself is the lightning strike: a rising edge on the input
+                // triggers it, it cracks up over RISE, falls over FALL with a
+                // high-rate flicker biting into it (the shock), and is then
+                // hard-zero — a held sustain keeps the input high but triggers
+                // nothing new, so the wires go dark while the note rings.
+                const _fwSpan = FRET_WIRE_HIT_RISE + FRET_WIRE_HIT_FALL;
                 let _fwLo = -1, _fwHi = -1;
                 for (let _f = 0; _f <= NFRETS; _f++) {
-                    const _g = Math.max(_fwHitIn[_f], _fwHitGlow[_f] * _fwDecay);
+                    const _in = _fwHitIn[_f];
+                    if (_in > 0.004 && _fwPrevIn[_f] <= 0.004) {
+                        _fwPulseT0[_f] = now;    // strike
+                        _fwPulseAmp[_f] = _in;
+                    }
+                    _fwPrevIn[_f] = _in;
+                    let _g = 0;
+                    const _pt = now - _fwPulseT0[_f];
+                    if (_pt >= 0 && _pt < _fwSpan) {
+                        if (_pt < FRET_WIRE_HIT_RISE) {
+                            _g = _pt / FRET_WIRE_HIT_RISE;
+                        } else {
+                            const _u = (_pt - FRET_WIRE_HIT_RISE) / FRET_WIRE_HIT_FALL;
+                            _g = (1 - _u) * (1 - _u);   // fast drop, easing out
+                            // Electric shudder during the fall only — the crack
+                            // itself stays clean.
+                            _g *= 1 - FRET_WIRE_HIT_FLICKER_DEPTH
+                                * (0.5 + 0.5 * Math.sin(_pt * 6.2832 * FRET_WIRE_HIT_FLICKER_HZ));
+                        }
+                        _g *= _fwPulseAmp[_f];
+                    } else if (_pt < 0) {
+                        _fwPulseT0[_f] = -Infinity; // seek landed before the strike
+                    }
                     _fwHitGlow[_f] = _g;
                     if (_g < 0.004) continue;   // below perceptible
                     if (_fwLo < 0) _fwLo = _f;

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -4789,19 +4789,21 @@
         const _scrStringSustain      = new Array(MAX_RENDER_STRINGS).fill(false);
         const _scrStringAnticipation = new Array(MAX_RENDER_STRINGS).fill(0);
         const _scrFretHeat           = new Array(NFRETS + 1).fill(0);
-        // Fret-wire hit flash. _fwHitIn is per-frame (cleared with the rest of
-        // the frame state, written by drawNote when a provider confirms a note).
-        // A RISING EDGE on it triggers a one-shot pulse: _fwPulseT0 records the
-        // strike's chart time, _fwPulseAmp its amplitude, _fwPrevIn detects the
-        // edge (a held 'active' verdict keeps the input high continuously, so a
-        // sustain triggers exactly one pulse — the wire goes dark while the
-        // note rings on). _fwHitGlow holds each wire's evaluated envelope value
-        // this frame, for the outer-pair selection below.
+        // Fret-wire hit flash. ONE strike per judged hit-zone event: the first
+        // frame a note (or strummed chord) gets a good verdict, its identity
+        // lands in _fwStruck and its wires get a strike request via _fwHitIn —
+        // and never again for that event, no matter how long the verdict stays
+        // live (a held sustain rings on with dark wires) and no matter what the
+        // per-wire input did between events (two consecutive correct notes on
+        // the SAME fret are two events → two strikes; an edge detector on the
+        // wire would have merged them). Same seen-map pattern as _sparkSeen.
+        // _fwPulseT0/_fwPulseAmp carry each wire's active pulse; _fwHitGlow is
+        // the evaluated envelope this frame, for the outer-pair selection.
         const _fwHitIn               = new Float32Array(NFRETS + 1);
         const _fwHitGlow             = new Float32Array(NFRETS + 1);
         const _fwPulseT0             = new Float32Array(NFRETS + 1).fill(-Infinity);
         const _fwPulseAmp            = new Float32Array(NFRETS + 1);
-        const _fwPrevIn              = new Float32Array(NFRETS + 1);
+        const _fwStruck              = new Map();
         // Per-frame chord accumulator. A chord flashes only the OUTERMOST wires
         // of its shape, but drawNote() sees one chord note at a time and can't
         // know the span — so hits accumulate here keyed by chord, and the flash
@@ -12695,9 +12697,14 @@
                 // open strings already use. The shape's own outer pair (wire
                 // behind the lowest fret, wire at the highest) survives only as
                 // the fallback for charts with no anchors.
-                for (const _fwE of _fwChordAcc.values()) {
+                for (const [_fwEK, _fwE] of _fwChordAcc) {
                     const _fwA = Math.max(_fwE.a, _fwE.openA);
                     if (_fwA <= 0) continue;
+                    // The strum is ONE event: strike its wires once, on the
+                    // first frame any member gets a good verdict.
+                    const _fwCK = 'c|' + _fwEK;
+                    if (_fwStruck.has(_fwCK)) continue;
+                    _fwStruck.set(_fwCK, now);
                     let _w0 = -1, _w1 = -1;
                     const _fwB = anchorLaneBoundsAt(_drawAnchors, _fwE.t);
                     if (_fwB) {
@@ -12717,8 +12724,9 @@
                     _fwHitGlow.fill(0);
                     _fwPulseT0.fill(-Infinity);
                     _fwPulseAmp.fill(0);
-                    _fwPrevIn.fill(0);
+                    _fwStruck.clear();  // replayed notes strike again after a seek
                 }
+                if (_fwStruck.size > 900) _fwStruck.clear(); // bounded, same as _sparkSeen
                 _fwHitPrevTime = now;
                 // Evaluate every wire's pulse, but flash only the OUTERMOST pair
                 // of lit wires (one bracket, never a picket fence — the chord
@@ -12731,12 +12739,15 @@
                 const _fwSpan = FRET_WIRE_HIT_RISE + FRET_WIRE_HIT_FALL;
                 let _fwLo = -1, _fwHi = -1;
                 for (let _f = 0; _f <= NFRETS; _f++) {
+                    // _fwHitIn is nonzero ONLY on the frame an event first lands
+                    // (the seen-map gates every producer), so any input is a
+                    // fresh strike — and it restarts a pulse already in flight,
+                    // which is what a rapid re-hit on the same wire should do.
                     const _in = _fwHitIn[_f];
-                    if (_in > 0.004 && _fwPrevIn[_f] <= 0.004) {
+                    if (_in > 0.004) {
                         _fwPulseT0[_f] = now;    // strike
                         _fwPulseAmp[_f] = _in;
                     }
-                    _fwPrevIn[_f] = _in;
                     let _g = 0;
                     const _pt = now - _fwPulseT0[_f];
                     if (_pt >= 0 && _pt < _fwSpan) {
@@ -14021,17 +14032,25 @@
                         _fwE.openA = _fwA;   // open strings in the chord → lane edges
                     }
                 } else if (n.f > 0 && n.f <= NFRETS) {
-                    if (_fwA > _fwHitIn[n.f - 1]) _fwHitIn[n.f - 1] = _fwA;
-                    if (_fwA > _fwHitIn[n.f]) _fwHitIn[n.f] = _fwA;
+                    const _fwK = 'n|' + s + '|' + n.f + '|' + n.t;
+                    if (!_fwStruck.has(_fwK)) {
+                        _fwStruck.set(_fwK, now);
+                        if (_fwA > _fwHitIn[n.f - 1]) _fwHitIn[n.f - 1] = _fwA;
+                        if (_fwA > _fwHitIn[n.f]) _fwHitIn[n.f] = _fwA;
+                    }
                 } else if (n.f === 0) {
                     // Sampled at the note's own time, matching how the open
                     // slab's width is derived (openNoteLaneBoxW(n.t)) — so the
                     // flashed wires are the ones the slab is actually drawn
                     // between, even if the lane has since moved.
-                    const _fwB = anchorLaneBoundsAt(_drawAnchors, n.t);
-                    if (_fwB) {
-                        if (_fwA > _fwHitIn[_fwB.dMin]) _fwHitIn[_fwB.dMin] = _fwA;
-                        if (_fwA > _fwHitIn[_fwB.dMax]) _fwHitIn[_fwB.dMax] = _fwA;
+                    const _fwK = 'n|' + s + '|0|' + n.t;
+                    if (!_fwStruck.has(_fwK)) {
+                        _fwStruck.set(_fwK, now);
+                        const _fwB = anchorLaneBoundsAt(_drawAnchors, n.t);
+                        if (_fwB) {
+                            if (_fwA > _fwHitIn[_fwB.dMin]) _fwHitIn[_fwB.dMin] = _fwA;
+                            if (_fwA > _fwHitIn[_fwB.dMax]) _fwHitIn[_fwB.dMax] = _fwA;
+                        }
                     }
                 }
             }

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -12680,10 +12680,28 @@
                     ? Math.exp(-_fwDt / FRET_WIRE_HIT_DECAY)
                     : 0;
                 _fwHitPrevTime = now;
+                // Decay EVERY wire's glow state, but flash only the OUTERMOST
+                // pair of lit wires. Fast passages overlap their decay tails, so
+                // without this a run of consecutive notes lights a picket fence
+                // of wires at once; collapsing to the outer pair keeps the whole
+                // lit span reading as ONE bracket — the same rule chords already
+                // follow, applied across everything currently glowing. Interior
+                // wires keep decaying invisibly (the base tier loop re-seeds
+                // their materials each frame), so the bracket tightens naturally
+                // as outer tails expire.
+                let _fwLo = -1, _fwHi = -1;
                 for (let _f = 0; _f <= NFRETS; _f++) {
                     const _g = Math.max(_fwHitIn[_f], _fwHitGlow[_f] * _fwDecay);
                     _fwHitGlow[_f] = _g;
-                    if (_g < 0.004) continue;   // below perceptible — skip the lerps
+                    if (_g < 0.004) continue;   // below perceptible
+                    if (_fwLo < 0) _fwLo = _f;
+                    _fwHi = _f;
+                }
+                for (let _i = 0; _i < 2; _i++) {
+                    const _f = _i === 0 ? _fwLo : _fwHi;
+                    if (_f < 0) break;                       // nothing lit
+                    if (_i === 1 && _f === _fwLo) break;     // single wire lit
+                    const _g = _fwHitGlow[_f];
                     const _m = fretWireMats[_f];
                     if (!_m) continue;
                     _m.color.lerp(_fwHitColor, _g);

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -921,13 +921,7 @@
     // The provider already fades its own `alpha` on a struck note; this tail
     // just keeps the hand-off from popping, and smooths the frame-to-frame
     // jitter of a held sustain (whose alpha tracks live input level).
-    // The flash is a one-shot "lightning strike" pulse, not a lingering glow:
-    // a near-instant crack up, then a fast shocked fall with an electric
-    // flicker, then HARD ZERO — a held sustain does not keep the wires lit.
-    const FRET_WIRE_HIT_RISE = 0.025;         // s, the crack — near-instant fade-in
-    const FRET_WIRE_HIT_FALL = 0.16;          // s, the shock dying out; dark after
-    const FRET_WIRE_HIT_FLICKER_HZ = 26;      // shudder rate during the fall
-    const FRET_WIRE_HIT_FLICKER_DEPTH = 0.35; // how deep the shudder bites (0..1)
+    const FRET_WIRE_HIT_DECAY = 0.32;
 
     const S_BASE = 3 * K;
     const S_GAP = 4 * K;
@@ -4789,21 +4783,12 @@
         const _scrStringSustain      = new Array(MAX_RENDER_STRINGS).fill(false);
         const _scrStringAnticipation = new Array(MAX_RENDER_STRINGS).fill(0);
         const _scrFretHeat           = new Array(NFRETS + 1).fill(0);
-        // Fret-wire hit flash. ONE strike per judged hit-zone event: the first
-        // frame a note (or strummed chord) gets a good verdict, its identity
-        // lands in _fwStruck and its wires get a strike request via _fwHitIn —
-        // and never again for that event, no matter how long the verdict stays
-        // live (a held sustain rings on with dark wires) and no matter what the
-        // per-wire input did between events (two consecutive correct notes on
-        // the SAME fret are two events → two strikes; an edge detector on the
-        // wire would have merged them). Same seen-map pattern as _sparkSeen.
-        // _fwPulseT0/_fwPulseAmp carry each wire's active pulse; _fwHitGlow is
-        // the evaluated envelope this frame, for the outer-pair selection.
+        // Fret-wire hit flash. _fwHitIn is per-frame (cleared with the rest of
+        // the frame state, written by drawNote when a provider confirms a note);
+        // _fwHitGlow persists across frames so the flash can decay smoothly
+        // rather than snapping off the frame the provider goes quiet.
         const _fwHitIn               = new Float32Array(NFRETS + 1);
         const _fwHitGlow             = new Float32Array(NFRETS + 1);
-        const _fwPulseT0             = new Float32Array(NFRETS + 1).fill(-Infinity);
-        const _fwPulseAmp            = new Float32Array(NFRETS + 1);
-        const _fwStruck              = new Map();
         // Per-frame chord accumulator. A chord flashes only the OUTERMOST wires
         // of its shape, but drawNote() sees one chord note at a time and can't
         // know the span — so hits accumulate here keyed by chord, and the flash
@@ -12697,14 +12682,9 @@
                 // open strings already use. The shape's own outer pair (wire
                 // behind the lowest fret, wire at the highest) survives only as
                 // the fallback for charts with no anchors.
-                for (const [_fwEK, _fwE] of _fwChordAcc) {
+                for (const _fwE of _fwChordAcc.values()) {
                     const _fwA = Math.max(_fwE.a, _fwE.openA);
                     if (_fwA <= 0) continue;
-                    // The strum is ONE event: strike its wires once, on the
-                    // first frame any member gets a good verdict.
-                    const _fwCK = 'c|' + _fwEK;
-                    if (_fwStruck.has(_fwCK)) continue;
-                    _fwStruck.set(_fwCK, now);
                     let _w0 = -1, _w1 = -1;
                     const _fwB = anchorLaneBoundsAt(_drawAnchors, _fwE.t);
                     if (_fwB) {
@@ -12720,51 +12700,23 @@
                 }
 
                 const _fwDt = now - _fwHitPrevTime;
-                if (!(_fwDt >= 0) || _fwDt > 1) {   // first frame, seek, or long stall
-                    _fwHitGlow.fill(0);
-                    _fwPulseT0.fill(-Infinity);
-                    _fwPulseAmp.fill(0);
-                    _fwStruck.clear();  // replayed notes strike again after a seek
-                }
-                if (_fwStruck.size > 900) _fwStruck.clear(); // bounded, same as _sparkSeen
+                if (!(_fwDt >= 0) || _fwDt > 1) _fwHitGlow.fill(0); // first frame, seek, or long stall
+                const _fwDecay = (_fwDt > 0 && _fwDt <= 1)
+                    ? Math.exp(-_fwDt / FRET_WIRE_HIT_DECAY)
+                    : 0;
                 _fwHitPrevTime = now;
-                // Evaluate every wire's pulse, but flash only the OUTERMOST pair
-                // of lit wires (one bracket, never a picket fence — the chord
-                // rule applied across everything currently pulsing). The pulse
-                // itself is the lightning strike: a rising edge on the input
-                // triggers it, it cracks up over RISE, falls over FALL with a
-                // high-rate flicker biting into it (the shock), and is then
-                // hard-zero — a held sustain keeps the input high but triggers
-                // nothing new, so the wires go dark while the note rings.
-                const _fwSpan = FRET_WIRE_HIT_RISE + FRET_WIRE_HIT_FALL;
+                // Decay EVERY wire's glow state, but flash only the OUTERMOST
+                // pair of lit wires. Fast passages overlap their decay tails, so
+                // without this a run of consecutive notes lights a picket fence
+                // of wires at once; collapsing to the outer pair keeps the whole
+                // lit span reading as ONE bracket — the same rule chords already
+                // follow, applied across everything currently glowing. Interior
+                // wires keep decaying invisibly (the base tier loop re-seeds
+                // their materials each frame), so the bracket tightens naturally
+                // as outer tails expire.
                 let _fwLo = -1, _fwHi = -1;
                 for (let _f = 0; _f <= NFRETS; _f++) {
-                    // _fwHitIn is nonzero ONLY on the frame an event first lands
-                    // (the seen-map gates every producer), so any input is a
-                    // fresh strike — and it restarts a pulse already in flight,
-                    // which is what a rapid re-hit on the same wire should do.
-                    const _in = _fwHitIn[_f];
-                    if (_in > 0.004) {
-                        _fwPulseT0[_f] = now;    // strike
-                        _fwPulseAmp[_f] = _in;
-                    }
-                    let _g = 0;
-                    const _pt = now - _fwPulseT0[_f];
-                    if (_pt >= 0 && _pt < _fwSpan) {
-                        if (_pt < FRET_WIRE_HIT_RISE) {
-                            _g = _pt / FRET_WIRE_HIT_RISE;
-                        } else {
-                            const _u = (_pt - FRET_WIRE_HIT_RISE) / FRET_WIRE_HIT_FALL;
-                            _g = (1 - _u) * (1 - _u);   // fast drop, easing out
-                            // Electric shudder during the fall only — the crack
-                            // itself stays clean.
-                            _g *= 1 - FRET_WIRE_HIT_FLICKER_DEPTH
-                                * (0.5 + 0.5 * Math.sin(_pt * 6.2832 * FRET_WIRE_HIT_FLICKER_HZ));
-                        }
-                        _g *= _fwPulseAmp[_f];
-                    } else if (_pt < 0) {
-                        _fwPulseT0[_f] = -Infinity; // seek landed before the strike
-                    }
+                    const _g = Math.max(_fwHitIn[_f], _fwHitGlow[_f] * _fwDecay);
                     _fwHitGlow[_f] = _g;
                     if (_g < 0.004) continue;   // below perceptible
                     if (_fwLo < 0) _fwLo = _f;
@@ -14032,25 +13984,17 @@
                         _fwE.openA = _fwA;   // open strings in the chord → lane edges
                     }
                 } else if (n.f > 0 && n.f <= NFRETS) {
-                    const _fwK = 'n|' + s + '|' + n.f + '|' + n.t;
-                    if (!_fwStruck.has(_fwK)) {
-                        _fwStruck.set(_fwK, now);
-                        if (_fwA > _fwHitIn[n.f - 1]) _fwHitIn[n.f - 1] = _fwA;
-                        if (_fwA > _fwHitIn[n.f]) _fwHitIn[n.f] = _fwA;
-                    }
+                    if (_fwA > _fwHitIn[n.f - 1]) _fwHitIn[n.f - 1] = _fwA;
+                    if (_fwA > _fwHitIn[n.f]) _fwHitIn[n.f] = _fwA;
                 } else if (n.f === 0) {
                     // Sampled at the note's own time, matching how the open
                     // slab's width is derived (openNoteLaneBoxW(n.t)) — so the
                     // flashed wires are the ones the slab is actually drawn
                     // between, even if the lane has since moved.
-                    const _fwK = 'n|' + s + '|0|' + n.t;
-                    if (!_fwStruck.has(_fwK)) {
-                        _fwStruck.set(_fwK, now);
-                        const _fwB = anchorLaneBoundsAt(_drawAnchors, n.t);
-                        if (_fwB) {
-                            if (_fwA > _fwHitIn[_fwB.dMin]) _fwHitIn[_fwB.dMin] = _fwA;
-                            if (_fwA > _fwHitIn[_fwB.dMax]) _fwHitIn[_fwB.dMax] = _fwA;
-                        }
+                    const _fwB = anchorLaneBoundsAt(_drawAnchors, n.t);
+                    if (_fwB) {
+                        if (_fwA > _fwHitIn[_fwB.dMin]) _fwHitIn[_fwB.dMin] = _fwA;
+                        if (_fwA > _fwHitIn[_fwB.dMax]) _fwHitIn[_fwB.dMax] = _fwA;
                     }
                 }
             }

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -12653,25 +12653,30 @@
             // backward resets it — otherwise a flash from a hit we jumped away
             // from would linger on the wire.
             if (fretWireMats.length && _fwHitColor) {
-                // Resolve accumulated chord hits: a chord flashes ONLY the wire
-                // behind its lowest fret and the wire at its highest, so the
-                // shape reads as one bracketed block rather than a picket fence
-                // of every wire in between. Open strings within the chord light
-                // the lane edges (they have no fret to bracket).
+                // Resolve accumulated chord hits: a chord's flash frames the
+                // LANE, not its own shape. The lit lane strip spans the anchor's
+                // width (min ~4 frets), which can run a fret past the chord's
+                // outermost fret — and a bracket one wire INSIDE the lit lane
+                // reads as misaligned. So a chord lights the anchor lane's edge
+                // wires: the exact wires the lane strip spans, and the same pair
+                // open strings already use. The shape's own outer pair (wire
+                // behind the lowest fret, wire at the highest) survives only as
+                // the fallback for charts with no anchors.
                 for (const _fwE of _fwChordAcc.values()) {
-                    if (_fwE.maxF >= _fwE.minF && _fwE.a > 0) {
-                        const _w0 = Math.max(0, _fwE.minF - 1);
-                        const _w1 = Math.min(NFRETS, _fwE.maxF);
-                        if (_fwE.a > _fwHitIn[_w0]) _fwHitIn[_w0] = _fwE.a;
-                        if (_fwE.a > _fwHitIn[_w1]) _fwHitIn[_w1] = _fwE.a;
+                    const _fwA = Math.max(_fwE.a, _fwE.openA);
+                    if (_fwA <= 0) continue;
+                    let _w0 = -1, _w1 = -1;
+                    const _fwB = anchorLaneBoundsAt(_drawAnchors, _fwE.t);
+                    if (_fwB) {
+                        _w0 = _fwB.dMin;
+                        _w1 = _fwB.dMax;
+                    } else if (_fwE.maxF >= _fwE.minF) {
+                        _w0 = Math.max(0, _fwE.minF - 1);
+                        _w1 = Math.min(NFRETS, _fwE.maxF);
                     }
-                    if (_fwE.openA > 0) {
-                        const _fwB = anchorLaneBoundsAt(_drawAnchors, _fwE.t);
-                        if (_fwB) {
-                            if (_fwE.openA > _fwHitIn[_fwB.dMin]) _fwHitIn[_fwB.dMin] = _fwE.openA;
-                            if (_fwE.openA > _fwHitIn[_fwB.dMax]) _fwHitIn[_fwB.dMax] = _fwE.openA;
-                        }
-                    }
+                    if (_w0 < 0) continue; // all-open chord on an anchor-less chart
+                    if (_fwA > _fwHitIn[_w0]) _fwHitIn[_w0] = _fwA;
+                    if (_fwA > _fwHitIn[_w1]) _fwHitIn[_w1] = _fwA;
                 }
 
                 const _fwDt = now - _fwHitPrevTime;

--- a/tests/js/highway_3d_render_order.test.js
+++ b/tests/js/highway_3d_render_order.test.js
@@ -1,8 +1,9 @@
 // Pins the renderOrder hierarchy in plugins/highway_3d/screen.js.
 //
 // Three.js renders transparent objects by renderOrder first, then back-to-front
-// Z sort within the same renderOrder. All 3D-highway materials use depthTest:false, so
-// renderOrder is the *only* draw-order control — getting it wrong silently
+// Z sort within the same renderOrder. Nearly all 3D-highway materials use
+// depthTest:false (exceptions exist — e.g. the accent halo mats set
+// depthTest:true), so renderOrder is the primary draw-order control — getting it wrong silently
 // causes one layer to bleed through another (gems clipping through chord frames,
 // strings buried under notes, etc.).
 //
@@ -199,17 +200,20 @@ test('static fret wires use bowed TubeGeometry + MeshStandardMaterial, named boa
         /FRET_WIRE_IDLE_HEX\s*=\s*0x4A4A60/,
         'FRET_WIRE_IDLE_HEX must be the dimmed idle gray-violet 0x4A4A60',
     );
-    // Both depth flags asserted independently so the test doesn't pin property
-    // order in the material literal.
+    // Both depth flags anchored to the fret-wire material literal (via its
+    // FRET_WIRE_IDLE_HEX color, unique to it) — an unscoped match would pass
+    // off any other depthTest:false material in the file. Asserted as two
+    // separate anchored matches so property order inside the literal still
+    // isn't pinned.
     assert.match(
         s,
-        /depthTest\s*:\s*false/,
-        'fret wire material must set depthTest: false',
+        /color\s*:\s*FRET_WIRE_IDLE_HEX[\s\S]{0,400}?depthTest\s*:\s*false/,
+        'the fret wire material itself must set depthTest: false',
     );
     assert.match(
         s,
-        /depthWrite\s*:\s*false/,
-        'fret wire material must set depthWrite: false (no z-buffer pollution)',
+        /color\s*:\s*FRET_WIRE_IDLE_HEX[\s\S]{0,400}?depthWrite\s*:\s*false/,
+        'the fret wire material itself must set depthWrite: false (no z-buffer pollution)',
     );
     assert.match(
         s,

--- a/tests/js/highway_3d_render_order.test.js
+++ b/tests/js/highway_3d_render_order.test.js
@@ -142,7 +142,7 @@ test('string mesh in buildBoard uses the named board-string layer', () => {
     assert.ok(layerIndex('BOARD_STRING') < layerIndex('BOARD_FRET_WIRE'));
 });
 
-test('static fret wires use bowed TubeGeometry + MeshStandardMaterial, named board-fret-wire layer, depthTest+depthWrite false, default gray 0x666688', () => {
+test('static fret wires use bowed TubeGeometry + MeshStandardMaterial, named board-fret-wire layer, depthTest+depthWrite false, idle tier FRET_WIRE_IDLE_HEX', () => {
     // Fret wires are a single shared, bowed TubeGeometry (backported from
     // highway_babylon): a CatmullRom curve whose middle pushes away from the
     // camera by FRET_BOW_DZ so the row of frets reads as wrapping a cylindrical
@@ -184,10 +184,19 @@ test('static fret wires use bowed TubeGeometry + MeshStandardMaterial, named boa
         /new\s+T\.MeshStandardMaterial\(/,
         'fret wires must use MeshStandardMaterial so scene light shades the metal',
     );
+    // The wire tiers moved to named constants (feedBack#969): idle is the
+    // dimmed 0x4A4A60 so the neck recedes and the anchor lane reads as the
+    // focus cue. Assert the material uses the constant AND pin the constant's
+    // value, so a retune is a deliberate two-line change here.
     assert.match(
         s,
-        /color\s*:\s*0x666688/,
-        'fret wire material must have default gray color 0x666688',
+        /color\s*:\s*FRET_WIRE_IDLE_HEX/,
+        'fret wire material must take its default color from FRET_WIRE_IDLE_HEX',
+    );
+    assert.match(
+        s,
+        /FRET_WIRE_IDLE_HEX\s*=\s*0x4A4A60/,
+        'FRET_WIRE_IDLE_HEX must be the dimmed idle gray-violet 0x4A4A60',
     );
     // Both depth flags asserted independently so the test doesn't pin property
     // order in the material literal.
@@ -208,7 +217,7 @@ test('static fret wires use bowed TubeGeometry + MeshStandardMaterial, named boa
     );
 });
 
-test('update() sets fret wire gold (0xD8A636) for in-anchor frets, gray (0x666688) otherwise', () => {
+test('update() sets fret wire FRET_WIRE_ACTIVE_HEX (gold) for in-anchor frets, FRET_WIRE_IDLE_HEX otherwise', () => {
     // Uses anchorLaneBoundsAt() — the same helper the dynamic lane uses —
     // so fret wire highlight aligns exactly with the lane edges:
     //   dMin = fret - 1,  dMax = fret + width - 1
@@ -226,13 +235,18 @@ test('update() sets fret wire gold (0xD8A636) for in-anchor frets, gray (0x66668
     );
     assert.match(
         s,
-        /_m\.color\.setHex\(\s*0xD8A636\s*\)/,
-        'update() must set gold 0xD8A636 for in-anchor fret wires',
+        /_m\.color\.setHex\(\s*FRET_WIRE_ACTIVE_HEX\s*\)/,
+        'update() must set FRET_WIRE_ACTIVE_HEX for in-anchor fret wires',
     );
     assert.match(
         s,
-        /_m\.color\.setHex\(\s*0x666688\s*\)/,
-        'update() must set gray 0x666688 for out-of-anchor fret wires',
+        /FRET_WIRE_ACTIVE_HEX\s*=\s*0xD8A636/,
+        'FRET_WIRE_ACTIVE_HEX must stay the anchor-lane gold 0xD8A636',
+    );
+    assert.match(
+        s,
+        /_m\.color\.setHex\(\s*FRET_WIRE_IDLE_HEX\s*\)/,
+        'update() must set FRET_WIRE_IDLE_HEX for out-of-anchor fret wires',
     );
     assert.match(
         s,

--- a/tests/js/highway_3d_render_order.test.js
+++ b/tests/js/highway_3d_render_order.test.js
@@ -11,6 +11,7 @@
 //   -1   background stage traversal
 //    1   lane quads
 //    2   fret dividers
+//    3   fret inlay dots (above the lane so it no longer hides them)
 //    4   sus-rail bloom (pSusRailBloom seed)           ← highway_3d_sustain_bloom.test.js
 //    5   sus-rail core (pSusRail seed)                 ← highway_3d_sustain_rail.test.js
 //    7   string-line glows (in-lane glow lines)


### PR DESCRIPTION
## What

The 3D highway's fret wires were static scenery — gold inside the anchor lane, grey outside, and nothing tied them to what the player was doing. This gives them a job:

1. **Widened the lane/neck contrast**, so the wires around the active lane read as a focus cue and the rest of the neck recedes.
2. **Made the wires slightly thicker** (and bumped the tube's radial segments, since a fatter tube shows its hexagonal facets).
3. **Flash the wires bracketing a note when a scorer confirms a hit**, so a hit registers on the board itself. Here is a good example of it in action for reference: https://www.youtube.com/watch?v=gIpDvz4PNaQ

Which wires flash depends on the note:

| | Wires lit |
|---|---|
| Fretted single note on fret `f` | `f-1` and `f` — the wire behind it, and the wire it's pressed against |
| Chord | Only the **outermost** wires of the shape (behind the lowest fret, at the highest). Frets 3/5/5 → wires 2 and 5, not 2‑3‑4‑5, so it reads as one bracketed block instead of a picket fence |
| Open string | The anchor **lane's edge wires**. An open string has no fret of its own, and its gem is drawn as a wide slab spanning the lane, so those are the wires it actually sits between |

## Verified on screen

Verified by the maintainer against a scripted note-state provider (a console-driven "perfect player" that confirms every note as it crosses the hit zone — the dev machine has no guitar attached). The additions below came out of that on-screen iteration.

## Additions since the first draft

- **At most two wires are ever lit** — overlapping decay tails (fast passages) collapse to the outermost pair of the lit span: one bracket, never a picket fence.
- **Chord flashes frame the lane, not the shape** — the lit lane strip can run a fret past the chord's outermost fret, and a bracket one wire inside the lit lane read as misaligned. Chords now light the anchor lane's edge wires (the same pair open strings use); the shape's own outer pair survives as the fallback on anchor-less charts.
- **Gem rims flash too** — on a confirmed hit the gem's outline lights in the string's own colour with the same intensity treatment as the wires, fading with the scorer's alpha. Just the rims: face fill and sustain trails unchanged.
- A pulse-envelope ("lightning strike") variant of the wire flash was tried and reverted in-branch; the shipped behaviour is the decaying glow described above.

## The levers — all named constants, all in one block

All in [`plugins/highway_3d/screen.js`](plugins/highway_3d/screen.js), in the fret-wire constants block next to `FRET_METALNESS` / `FRET_BOW_DZ`. Nothing here is derived from anything else, so each can be moved independently.

### Hit flash

| Constant | Now | What it does |
|---|---|---|
| `FRET_WIRE_HIT_INTENSITY` | `4.2` | **The main brightness knob.** Multiplies `emissiveIntensity` at full flash (baseline `1`). This is what makes a wire read as a *light source* rather than a brightly-lit object. Went `3.0 → 6.0 → 4.2`; last feedback on `6.0` was "slightly too bright", so `4.2` is an untested guess between. |
| `FRET_WIRE_HIT_DECAY` | `0.32` | **The linger knob.** Seconds for a flash to fall to ~1/e once the provider stops reporting. Deliberately independent of brightness — *a long tail can read as "too bright" even when the peak is right*, so if it feels hot, try trimming this to ~`0.22` **before** dropping the intensity. |
| `FRET_WIRE_HIT_EMISSIVE` | `0xFFE9B0` | Glow colour at full flash (hot warm-white). |
| `FRET_WIRE_HIT_HEX` | `0xFFFFFF` | Albedo at full flash. Has less effect than you'd expect — see the note below. |
| `FRET_WIRE_HIT_OP` | `1.0` | Opacity at full flash. |

**Why emissive and not colour:** these are `MeshStandardMaterial` in a scene with **no envMap**, so raising albedo alone barely brightens them — it saturates toward white and stops. `emissiveIntensity` is the lever with real range. Corollary: there's **no bloom/post-processing pass** in this scene, so past ~8 you're just painting white pixels for longer and can't get glow *bleed* into the surrounding area. If it needs to be brighter than the material can go, the next step is an additive halo mesh around the flashing wire — a bigger change, not a constant.

### Base look (the two idle tiers)

| Constant | Now | Was |
|---|---|---|
| `FRET_WIRE_ACTIVE_HEX` / `_OP` | `0xD8A636` / `0.9` | `0xD8A636` / `0.8` |
| `FRET_WIRE_IDLE_HEX` / `_OP` | `0x4A4A60` / `0.28` | `0x666688` / `0.4` |
| `FRET_TUBE_RADIUS` | `STR_THICK * 0.75` | `* 0.55` |
| `FRET_TUBE_RADIAL` | `8` | `6` |

## Things to actually look at when picking this up

- **Fast passages.** With a `0.32` s tail, consecutive notes on nearby frets overlap their flashes, so neighbouring wires may stay lit more or less continuously. That could look great (a glowing band tracking your hand) or muddy (nothing ever goes dark). This is the single most likely thing to need tuning.
- **Held sustains.** The provider returns `alpha` tracking live input level for a held note, which jitters frame to frame. The decay tail is what smooths it — check it's actually smooth and not pulsing.
- **High frets under fog.** The idle tier is dimmer now (`0.28` vs `0.4`); confirm distant wires haven't been swallowed entirely.
- **Charts with no anchors.** `anchorLaneBoundsAt` returns null, so open-string flashes silently do nothing (fretted notes are unaffected). Rare — GP imports synthesise anchors — but it's the one case that fails quietly rather than visibly.

## Implementation notes for a reviewer

- **Gated on the provider verdict (`_ndGood`), never the proximity `hit` heuristic.** The latter only means "near the strike line" — using it would flash on every passing note whether or not it was played. So with **no scorer attached, the neck behaves exactly as it does today**.
- **Two passes, deliberately.** The base tier loop (gold/grey) runs near the top of `update()`, long before any note is drawn. The flash is applied in a second pass *after* the note and chord draw loops, so it sees this frame's verdicts rather than the previous frame's. `emissive` / `emissiveIntensity` are re-seeded to baseline in the tier loop each frame — without that, a flash would never fade back out.
- **Chords accumulate.** `drawNote()` is the chord loop's per-note call and can't see the chord's span, so chord hits collect into a small `Map` (keyed by chord id, falling back to chord time — `ch.id` can be absent, a documented pitfall) and the flash pass resolves min/max fret into the outer wire pair. This avoided restructuring the chord loop with begin/end hooks.
- **The flash decays in _chart_ time**, so it respects playback speed, and a backward seek clears it rather than leaving a stale flash on a wire you jumped away from.
- `drawNote()` is a sibling of `update()`, not nested in it, so the anchors are snapshotted into a closure var (`_drawAnchors`) — following the pattern already established there for `_drawChordTemplates`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the Unreleased changelog with updates covering career and passport gameplay, gigs, Gold tier progression, stems support, genre enrichment, and 3D highway improvements.
  - Added notes on navigation, song-grid performance, library filtering, playlists, resume and exit flows, settings, themes, and working tuning.
  - Documented plugin-system enhancements, architectural improvements, performance updates, and security fixes.

- **Chores**
  - Updated the 3D highway plugin version to 3.32.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
