### PR TITLE
fix(plugins): restore window.esc for out-of-tree plugins

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2319,11 +2319,14 @@ configureHost({
     currentFilename: () => currentFilename,
 });
 
+// `esc` is here for out-of-tree plugins only: their screen.js loads as a classic
+// script and called esc() back when app.js was one too and it was an implicit
+// global. Nothing in core reads window.esc — import it from ./js/dom.js instead.
 Object.assign(window, {
     _confirmDialog, _getArrangementNamingMode, _libraryLocalFilename, _librarySongArtUrl,
     _librarySongId, _onHeaderClick, _onNamingModeChange, _trapFocusInModal,
     changeArrangement, checkPluginUpdates, clearLibFilters, clearLoop,
-    deleteSelectedLoop, exportDiagnostics, exportSettings, filterFavorites,
+    deleteSelectedLoop, esc, exportDiagnostics, exportSettings, filterFavorites,
     filterLibrary, fullRescanLibrary, goFavPage, handleSliderInput,
     hideScanBanner, importSettings, loadPlugins, loadSavedLoop,
     loadSettings, onSectionPracticeModeChange, openEditModal, persistSetting,

--- a/tests/browser/plugin-globals-contract.spec.ts
+++ b/tests/browser/plugin-globals-contract.spec.ts
@@ -1,0 +1,63 @@
+// The window globals are a THIRD-PARTY CONTRACT. Pin them.
+//
+// Out-of-tree plugins load their screen.js as a CLASSIC script and call these
+// as bare globals. Nothing in core reads most of them, so a call-graph scan,
+// ESLint's no-undef, and a grep all come back clean while the plugin breaks in
+// the field. This is the frontend twin of tests/test_plugin_context_contract.py
+// — same reasoning, same literal-list rule.
+//
+// This guard is retroactive: `esc` was an implicit global back when app.js was
+// a classic script, went module-scoped in a9fce29, and got carved into
+// js/dom.js in 14b4058. The re-export list at the bottom of app.js was rebuilt
+// without it, and the MIDI plugin's device list threw "esc is not defined" for
+// testers — reported as "MIDI Access denied", because the ReferenceError landed
+// in a try/catch meant for permission failures.
+//
+// WHY A LITERAL LIST AND NOT A DERIVED ONE. Deriving the expected set from
+// app.js would assert the code equals itself. The point is that a human has to
+// look at a diff and consciously agree to change the contract.
+
+import { test, expect } from '@playwright/test';
+
+const PLUGIN_GLOBALS = [
+  '_confirmDialog', '_getArrangementNamingMode', '_libraryLocalFilename', '_librarySongArtUrl',
+  '_librarySongId', '_onHeaderClick', '_onNamingModeChange', '_trapFocusInModal',
+  'changeArrangement', 'checkPluginUpdates', 'clearLibFilters', 'clearLoop',
+  'deleteSelectedLoop', 'esc', 'exportDiagnostics', 'exportSettings', 'filterFavorites',
+  'filterLibrary', 'fullRescanLibrary', 'goFavPage', 'handleSliderInput',
+  'hideScanBanner', 'importSettings', 'loadPlugins', 'loadSavedLoop',
+  'loadSettings', 'onSectionPracticeModeChange', 'openEditModal', 'persistSetting',
+  'pickDlcFolder', 'pinCurrentArrangementDefault', 'playSong', 'previewDiagnostics',
+  'previewEditArt', 'renderGridCards', 'renderTreeInto', 'rescanLibrary',
+  'retuneSong', 'saveCurrentLoop', 'saveSettings', 'seekBy',
+  'setAvOffsetMs', 'setFavView', 'setInstrumentPathway', 'setLibView',
+  'setLibraryProvider', 'setLoopEnd', 'setLoopStart', 'setMastery',
+  'setSpeed', 'setViz', 'showScreen', 'sortFavorites',
+  'sortLibrary', 'syncLibrarySong', 'toggleAllArtists', 'toggleAllFavoriteArtists',
+  'toggleLibFilters', 'togglePlay', 'toggleSectionPracticePopover', 'uiPrompt',
+  'updatePlugin', 'uploadSongs',
+  'filterFavTreeLetter', 'filterTreeLetter', 'goFavTreePage', 'goTreePage',
+];
+
+test('plugin-facing window globals are all callable', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForSelector('.screen.active', { timeout: 10000 });
+
+  const missing = await page.evaluate(
+    (names) => names.filter((n) => typeof (window as any)[n] !== 'function'),
+    PLUGIN_GLOBALS,
+  );
+
+  expect(missing, `window globals plugins depend on are missing or not functions: ${missing.join(', ')}`).toEqual([]);
+});
+
+// The plugin call site that actually broke: esc() interpolated into a template
+// string. A global that exists but doesn't escape is its own bug.
+test('window.esc escapes HTML metacharacters', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForSelector('.screen.active', { timeout: 10000 });
+
+  const escaped = await page.evaluate(() => (window as any).esc('<img src=x onerror=alert(1)>'));
+  expect(escaped).not.toContain('<img');
+  expect(escaped).toContain('&lt;');
+});


### PR DESCRIPTION
## What testers saw

> MIDI control no longer works — **"MIDI Access denied esc is not defined"**

MIDI access was never denied. It was granted. The error message is two unrelated things glued together.

`plugins/midi/screen.js` builds its device dropdown with `esc(o.name)`, and the call sits *inside* the try block guarding `requestMIDIAccess()`:

```js
try {
    _midiAccess = await navigator.requestMIDIAccess({ sysex: false });  // succeeds
    _updateMidiDevices();   // throws ReferenceError: esc is not defined
} catch (e) {
    // ...renders "MIDI access denied" with e.message
}
```

So a `ReferenceError` from the device list gets reported by the handler meant for permission failures. Testers with working hardware and granted permission still see "access denied".

## Root cause

`esc()` was a top-level function in `static/app.js` back when app.js was a **classic script**, which made it an implicit global any plugin could call.

- `a9fce29` made app.js an ES module → top-level names became module-scoped.
- `14b4058` carved `esc` out into `js/dom.js`.
- The `Object.assign(window, {...})` block that hands globals back to plugins was rebuilt **without** `esc`.

In-tree plugins were unaffected because they each define a local `esc` (`career`, `achievements`, `input_setup`, …). Out-of-tree plugins rely on the host's.

## Why fix it here and not in the MIDI plugin

**Four** bundled plugins call `esc()` bare with no local definition — `midi`, `multiplayer`, `nam_tone`, `practice`. Only MIDI was reported. One entry in the export list fixes all four; patching MIDI alone leaves three broken.

## The guard

`tests/test_plugin_context_contract.py` already pins the **server-side** plugin context by name, and its docstring says exactly why:

> *"Same lesson the frontend carve learned the hard way: a contract that only external code reads cannot be found by a call-graph scan, so it has to be pinned by name."*

That lesson was written down but only applied to the server side. This adds the frontend twin — a literal-list pin of the plugin-facing window surface, same reasoning, same no-derived-list rule. Relevant with the module-refactor epic still open (#879, #901–#904, #917).

## Verification

Both directions, against a running app in real Chromium:

- **With** the fix → spec passes.
- **Without** it → fails with `window globals plugins depend on are missing or not functions: esc` — the tester's bug, reproduced.

⚠️ **The `./static:/app/static` live-reload mount in `docker-compose.yml` does not propagate edits** — the container snapshots at boot. My first run passed *without* the fix because it was serving a stale file; `md5sum` on disk vs. in-container confirmed the drift. Every result above required `docker compose restart web`. Worth knowing for anyone trusting that mount.

- `npm run lint` → 0 errors (12 pre-existing warnings)
- `npm run test:js` → 1099/1099
- `codex exec` preflight → NO ISSUES

## Not in this PR

- Core-only. Testers won't see it until a desktop re-bundle of `resources/slopsmith/`.
- The MIDI plugin's `catch` reports *any* exception as "access denied". Moving `_updateMidiDevices()` outside the try would stop future bugs wearing a permissions costume — that's an out-of-tree repo, so it's a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the globally available `esc` utility for browser plugins.
  * Ensured HTML content is safely escaped, helping prevent unescaped markup from being rendered.

* **Tests**
  * Added browser coverage verifying required plugin globals are available and function correctly.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->