### PR TITLE
Enable Linux nightly AppImage auto-update in the System settings UI

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -209,7 +209,7 @@ export function setupWindowOptions() {
     }
 }
 
-export const APP_UPDATE_CHANNELS = ['stable', 'rc', 'beta', 'alpha'];
+export const APP_UPDATE_CHANNELS = ['stable', 'rc', 'beta', 'alpha', 'nightly'];
 
 export let _appUpdatesWired = false;
 
@@ -245,11 +245,13 @@ export function setupAppUpdates() {
     const stored = APP_UPDATE_CHANNELS.includes(storedRaw) ? storedRaw : 'stable';
     channelSelect.value = stored;
 
-    const isLinux = window.feedBackDesktop?.platform === 'linux';
-
     function showLinuxFallback(message) {
+        // Deliberately leaves channelSelect ENABLED: on Linux "unsupported"
+        // usually just means "the channel isn't Nightly yet", and the dropdown
+        // is the only way to switch to Nightly. Disabling it would trap the
+        // user on whatever channel they booted with. Only the check button and
+        // the note reflect the unsupported state.
         if (linuxNote) linuxNote.classList.remove('hidden');
-        channelSelect.disabled = true;
         checkBtn.disabled = true;
         statusEl.textContent = message || 'Auto-update is not available on this platform.';
     }
@@ -269,9 +271,13 @@ export function setupAppUpdates() {
             void Promise.resolve(updateApi.getStatus()).then((s) => {
                 if (!s) { statusEl.textContent = extra || 'Updater status unavailable.'; return; }
                 if (s.status === 'unsupported' || s.platform === 'linux') {
-                    showLinuxFallback('Auto-update is not available on Linux.');
+                    showLinuxFallback('Auto-update requires the AppImage build on the Nightly channel.');
                     return;
                 }
+                // Status is healthy for the current channel — clear any
+                // "unsupported" UI left over from a prior channel selection.
+                if (linuxNote) linuxNote.classList.add('hidden');
+                checkBtn.disabled = false;
                 if (s.status === 'error') {
                     const errMsg = s.message ? `Update error: ${s.message}` : 'Update check failed.';
                     statusEl.textContent = extra ? `${extra} · ${errMsg}` : errMsg;
@@ -293,24 +299,10 @@ export function setupAppUpdates() {
         }
     }
 
-    if (isLinux) {
-        showLinuxFallback('Auto-update is not available on Linux.');
-        // Keep main informed of the persisted channel even on Linux so
-        // cross-platform reasoning about the channel stays consistent.
-        // setChannel() may return a Promise — chain .catch() so a rejected
-        // promise doesn't surface as an unhandled rejection.
-        try {
-            void Promise.resolve(updateApi.setChannel(stored)).catch((e) => {
-                console.warn('[updater] setChannel(linux) failed:', e);
-            });
-        } catch (e) {
-            console.warn('[updater] setChannel(linux) threw:', e);
-        }
-        return;
-    }
-
     // Inform main of the persisted channel on each load. setChannel() on
-    // main is idempotent when the channel already matches.
+    // main is idempotent when the channel already matches. On Linux this is
+    // how the panel reaches a supported state: booting on 'stable' reports
+    // unsupported, and switching the dropdown to Nightly re-checks below.
     try {
         void Promise.resolve(updateApi.setChannel(stored)).catch((e) => {
             console.warn('[updater] setChannel(initial) failed:', e);
@@ -359,7 +351,7 @@ export function setupAppUpdates() {
                         break;
                     case 'unsupported':
                         reEnableBtn = false;
-                        showLinuxFallback('Auto-update is not available on Linux.');
+                        showLinuxFallback('Auto-update requires the AppImage build on the Nightly channel.');
                         return;
                     case 'error':
                         msg = `Update check failed${result?.message ? `: ${result.message}` : '.'}`;

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -248,6 +248,15 @@ export function setupAppUpdates() {
     const stored = APP_UPDATE_CHANNELS.includes(storedRaw) ? storedRaw : 'stable';
     channelSelect.value = stored;
 
+    // Diagnostic: every entry into this function, with whether the one-time
+    // sync gate has already fired. _appUpdatesWired is a MODULE-level `let`,
+    // so it only resets to false on a genuine fresh evaluation of this
+    // script (a real page reload/navigation) — not on loadSettings() simply
+    // being called again within the same page. A second "wired=false" in one
+    // exported log is direct proof of a reload; a series of "wired=true"
+    // entries proves it's just repeated Settings-panel visits (harmless).
+    console.log('[update-diag] setupAppUpdates() entered', JSON.stringify({ wired: _appUpdatesWired, stored }));
+
     function showLinuxFallback(message) {
         // Deliberately leaves channelSelect ENABLED: on Linux "unsupported"
         // usually just means "the channel isn't Nightly yet", and the dropdown

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -283,6 +283,23 @@ export function setupAppUpdates() {
                     statusEl.textContent = extra ? `${extra} · ${errMsg}` : errMsg;
                     return;
                 }
+                // Surface the live activity states explicitly so the panel says
+                // what it's doing — including when it (re)loads mid-download,
+                // where only getStatus (not the one-shot event listeners) can
+                // tell us we're downloading.
+                if (s.status === 'checking') {
+                    statusEl.textContent = 'Checking for updates…';
+                    return;
+                }
+                if (s.status === 'downloading') {
+                    const pct = typeof s.percent === 'number' ? s.percent : null;
+                    statusEl.textContent = pct === null ? 'Update available — downloading…' : `Downloading update… ${pct}%`;
+                    return;
+                }
+                if (s.status === 'downloaded') {
+                    statusEl.textContent = 'Update ready — restart to apply.';
+                    return;
+                }
                 const parts = [
                     `Version ${s.currentVersion || '?'}`,
                     `channel ${s.channel || channelSelect.value}`,
@@ -382,6 +399,9 @@ export function setupAppUpdates() {
                 const pct = typeof p?.percent === 'number' ? p.percent : null;
                 statusEl.textContent = pct === null ? 'Downloading update…' : `Downloading update… ${pct}%`;
             });
+        }
+        if (typeof updateApi.onDownloaded === 'function') {
+            updateApi.onDownloaded(() => { statusEl.textContent = 'Update ready — restart to apply.'; });
         }
 
         _appUpdatesWired = true;

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -368,6 +368,22 @@ export function setupAppUpdates() {
             }
         });
 
+        // Download feedback. The Linux AppImage self-update pulls a full
+        // ~1.5GB image in the main process, so without these the status would
+        // sit at "Checking for updates…" for minutes with no sign of life.
+        // onAvailable fires when the download starts; onProgress ticks the
+        // percentage. Guarded individually — an older desktop bridge may not
+        // expose them.
+        if (typeof updateApi.onAvailable === 'function') {
+            updateApi.onAvailable(() => { statusEl.textContent = 'Downloading update…'; });
+        }
+        if (typeof updateApi.onProgress === 'function') {
+            updateApi.onProgress((p) => {
+                const pct = typeof p?.percent === 'number' ? p.percent : null;
+                statusEl.textContent = pct === null ? 'Downloading update…' : `Downloading update… ${pct}%`;
+            });
+        }
+
         _appUpdatesWired = true;
     }
 

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -396,16 +396,23 @@ export function setupAppUpdates() {
         }, 1500);
     }
 
-    // Inform main of the persisted channel on each load. setChannel() on
-    // main is idempotent when the channel already matches. On Linux this is
-    // how the panel reaches a supported state: booting on 'stable' reports
-    // unsupported, and switching the dropdown to Nightly re-checks below.
-    try {
-        void Promise.resolve(updateApi.setChannel(stored)).catch((e) => {
-            console.warn('[updater] setChannel(initial) failed:', e);
-        });
-    } catch (e) {
-        console.warn('[updater] setChannel(initial) threw:', e);
+    // Inform main of the persisted channel — but ONLY the first time this page
+    // wires up, not on every loadSettings() re-render. This used to run
+    // unconditionally on every call and was caught (via Export Diagnostics)
+    // stomping an in-flight check/download: a redundant setChannel() call
+    // mid-download bumps main's checkGeneration and resets progress state,
+    // so the download silently loses its ability to report completion even
+    // though the file swap itself still happens in the background. Once
+    // wired, the channel select's own 'change' handler is the only thing
+    // that needs to tell main about a channel switch.
+    if (!_appUpdatesWired) {
+        try {
+            void Promise.resolve(updateApi.setChannel(stored)).catch((e) => {
+                console.warn('[updater] setChannel(initial) failed:', e);
+            });
+        } catch (e) {
+            console.warn('[updater] setChannel(initial) threw:', e);
+        }
     }
 
     if (!_appUpdatesWired) {

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -212,6 +212,9 @@ export function setupWindowOptions() {
 export const APP_UPDATE_CHANNELS = ['stable', 'rc', 'beta', 'alpha', 'nightly'];
 
 export let _appUpdatesWired = false;
+// Poll handle for the active-download watcher (module-scoped so re-running
+// setupAppUpdates on a panel re-render never stacks a second poll).
+let _appUpdatePollTimer = null;
 
 export function setupAppUpdates() {
     const block = document.getElementById('app-updates-block');
@@ -264,56 +267,84 @@ export function setupAppUpdates() {
         } catch (_) { return 'never'; }
     }
 
+    // Render one status object. Always keeps the current version + channel
+    // visible and appends what's happening, so the download progress never
+    // obscures which build you're on.
+    function renderFrom(s, extra) {
+        if (!s) { statusEl.textContent = extra || 'Updater status unavailable.'; return; }
+        if (s.status === 'unsupported' || s.platform === 'linux') {
+            showLinuxFallback('Auto-update requires the AppImage build on the Nightly channel.');
+            return;
+        }
+        // Healthy for the current channel — clear any "unsupported" UI left
+        // over from a prior channel selection.
+        if (linuxNote) linuxNote.classList.add('hidden');
+        checkBtn.disabled = false;
+        const base = `Version ${s.currentVersion || '?'} · ${s.channel || channelSelect.value}`;
+        let action;
+        switch (s.status) {
+            case 'checking':
+                action = 'checking for updates…';
+                break;
+            case 'downloading': {
+                const pct = typeof s.percent === 'number' ? s.percent : null;
+                action = pct === null ? 'update available — downloading…' : `downloading update… ${pct}%`;
+                break;
+            }
+            case 'downloaded':
+                action = 'update ready — restart to apply';
+                break;
+            case 'error':
+                action = s.message ? `update error: ${s.message}` : 'update check failed';
+                break;
+            case 'idle':
+            default:
+                action = `up to date · last checked ${fmtTimestamp(s.lastChecked)}`;
+                break;
+        }
+        const line = `${base} · ${action}`;
+        statusEl.textContent = extra ? `${extra} · ${line}` : line;
+        // A download runs in the background (the check returns immediately), so
+        // poll for the terminal state rather than relying solely on a one-shot
+        // "downloaded" event that could be missed or arrive out of order.
+        if (s.status === 'downloading' || s.status === 'checking') pollWhileBusy();
+    }
+
     function renderStatus(extra) {
         try {
             // Wrap in Promise.resolve so a future getStatus() that returns
             // synchronously won't blow up on .then().
-            void Promise.resolve(updateApi.getStatus()).then((s) => {
-                if (!s) { statusEl.textContent = extra || 'Updater status unavailable.'; return; }
-                if (s.status === 'unsupported' || s.platform === 'linux') {
-                    showLinuxFallback('Auto-update requires the AppImage build on the Nightly channel.');
-                    return;
-                }
-                // Status is healthy for the current channel — clear any
-                // "unsupported" UI left over from a prior channel selection.
-                if (linuxNote) linuxNote.classList.add('hidden');
-                checkBtn.disabled = false;
-                if (s.status === 'error') {
-                    const errMsg = s.message ? `Update error: ${s.message}` : 'Update check failed.';
-                    statusEl.textContent = extra ? `${extra} · ${errMsg}` : errMsg;
-                    return;
-                }
-                // Surface the live activity states explicitly so the panel says
-                // what it's doing — including when it (re)loads mid-download,
-                // where only getStatus (not the one-shot event listeners) can
-                // tell us we're downloading.
-                if (s.status === 'checking') {
-                    statusEl.textContent = 'Checking for updates…';
-                    return;
-                }
-                if (s.status === 'downloading') {
-                    const pct = typeof s.percent === 'number' ? s.percent : null;
-                    statusEl.textContent = pct === null ? 'Update available — downloading…' : `Downloading update… ${pct}%`;
-                    return;
-                }
-                if (s.status === 'downloaded') {
-                    statusEl.textContent = 'Update ready — restart to apply.';
-                    return;
-                }
-                const parts = [
-                    `Version ${s.currentVersion || '?'}`,
-                    `channel ${s.channel || channelSelect.value}`,
-                    `last checked ${fmtTimestamp(s.lastChecked)}`,
-                ];
-                statusEl.textContent = extra ? `${extra} · ${parts.join(' · ')}` : parts.join(' · ');
-            }).catch((e) => {
-                console.warn('[updater] getStatus failed:', e);
-                statusEl.textContent = extra || 'Failed to read updater status.';
-            });
+            void Promise.resolve(updateApi.getStatus())
+                .then((s) => renderFrom(s, extra))
+                .catch((e) => {
+                    console.warn('[updater] getStatus failed:', e);
+                    statusEl.textContent = extra || 'Failed to read updater status.';
+                });
         } catch (e) {
             console.warn('[updater] getStatus threw:', e);
             statusEl.textContent = extra || 'Failed to read updater status.';
         }
+    }
+
+    // While a download (or check) is active, re-read the authoritative status
+    // every ~1.5s and stop once it settles (downloaded / idle / error). This is
+    // what guarantees the panel leaves "downloading… 100%" and lands on "update
+    // ready" (or surfaces a swap error) even if the completion event is lost.
+    function pollWhileBusy() {
+        if (_appUpdatePollTimer) return;
+        _appUpdatePollTimer = setInterval(() => {
+            void Promise.resolve(updateApi.getStatus()).then((s) => {
+                renderFrom(s);
+                const st = s && s.status;
+                if (st !== 'downloading' && st !== 'checking') {
+                    clearInterval(_appUpdatePollTimer);
+                    _appUpdatePollTimer = null;
+                }
+            }).catch(() => {
+                clearInterval(_appUpdatePollTimer);
+                _appUpdatePollTimer = null;
+            });
+        }, 1500);
     }
 
     // Inform main of the persisted channel on each load. setChannel() on
@@ -351,58 +382,20 @@ export function setupAppUpdates() {
         checkBtn.addEventListener('click', async () => {
             checkBtn.disabled = true;
             statusEl.textContent = 'Checking for updates…';
-            let reEnableBtn = true;
             try {
-                const result = await updateApi.checkNow();
-                const status = result?.status || 'unknown';
-                let msg;
-                switch (status) {
-                    case 'idle':
-                        msg = "You're on the newest version in this channel.";
-                        break;
-                    case 'downloading':
-                        msg = 'Update available — downloading…';
-                        break;
-                    case 'downloaded':
-                        msg = 'Update downloaded — restart to apply.';
-                        break;
-                    case 'unsupported':
-                        reEnableBtn = false;
-                        showLinuxFallback('Auto-update requires the AppImage build on the Nightly channel.');
-                        return;
-                    case 'error':
-                        msg = `Update check failed${result?.message ? `: ${result.message}` : '.'}`;
-                        break;
-                    default:
-                        msg = `Update check returned: ${status}`;
-                }
-                renderStatus(msg);
+                // The Linux check returns immediately (any download runs in the
+                // background); we don't act on the returned status directly —
+                // renderStatus() below reads the authoritative state and starts
+                // the progress poll if a download is now under way.
+                await updateApi.checkNow();
             } catch (e) {
                 console.warn('[updater] checkNow failed:', e);
                 statusEl.textContent = `Update check failed: ${e?.message || e}`;
-            } finally {
-                if (reEnableBtn) checkBtn.disabled = false;
+                checkBtn.disabled = false;
+                return;
             }
+            renderStatus();
         });
-
-        // Download feedback. The Linux AppImage self-update pulls a full
-        // ~1.5GB image in the main process, so without these the status would
-        // sit at "Checking for updates…" for minutes with no sign of life.
-        // onAvailable fires when the download starts; onProgress ticks the
-        // percentage. Guarded individually — an older desktop bridge may not
-        // expose them.
-        if (typeof updateApi.onAvailable === 'function') {
-            updateApi.onAvailable(() => { statusEl.textContent = 'Downloading update…'; });
-        }
-        if (typeof updateApi.onProgress === 'function') {
-            updateApi.onProgress((p) => {
-                const pct = typeof p?.percent === 'number' ? p.percent : null;
-                statusEl.textContent = pct === null ? 'Downloading update…' : `Downloading update… ${pct}%`;
-            });
-        }
-        if (typeof updateApi.onDownloaded === 'function') {
-            updateApi.onDownloaded(() => { statusEl.textContent = 'Update ready — restart to apply.'; });
-        }
 
         _appUpdatesWired = true;
     }

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -407,7 +407,21 @@ export function setupAppUpdates() {
     // that needs to tell main about a channel switch.
     if (!_appUpdatesWired) {
         try {
-            void Promise.resolve(updateApi.setChannel(stored)).catch((e) => {
+            // Render from THIS call's own result (same reasoning as the check
+            // button and the 'change' handler below), not just catch its
+            // errors. The unconditional renderStatus() at the bottom of this
+            // function fires a SEPARATE getStatus() round-trip immediately
+            // after — if that resolves before main has processed this
+            // setChannel() (e.g. main is still on its 'stable' boot default),
+            // the UI would render 'unsupported' and — since this call's own
+            // eventual success was never rendered — get stuck there
+            // permanently, even once main correctly switches channel a moment
+            // later. Rendering here too means whichever of the two calls
+            // resolves LAST wins and shows the true state, regardless of
+            // which order they land in.
+            void Promise.resolve(updateApi.setChannel(stored)).then((result) => {
+                renderFrom(result);
+            }).catch((e) => {
                 console.warn('[updater] setChannel(initial) failed:', e);
             });
         } catch (e) {

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -256,6 +256,10 @@ export function setupAppUpdates() {
         // the note reflect the unsupported state.
         if (linuxNote) linuxNote.classList.remove('hidden');
         checkBtn.disabled = true;
+        // Reset the button out of any leftover "Restart now" state (e.g. an
+        // update was staged on nightly, then the user switched channels).
+        checkBtn.textContent = 'Check for updates';
+        checkBtn.dataset.mode = 'check';
         statusEl.textContent = message || 'Auto-update is not available on this platform.';
     }
 
@@ -279,20 +283,35 @@ export function setupAppUpdates() {
         // Healthy for the current channel — clear any "unsupported" UI left
         // over from a prior channel selection.
         if (linuxNote) linuxNote.classList.add('hidden');
-        checkBtn.disabled = false;
         const base = `Version ${s.currentVersion || '?'} · ${s.channel || channelSelect.value}`;
+        // The button is a little state machine driven by the status: grayed
+        // out while a check/download is in flight, flipped to "Restart now"
+        // (dataset.mode='restart', consumed by the click handler) once an
+        // update is staged, and back to a plain check button otherwise.
         let action;
+        let btnLabel = 'Check for updates';
+        let btnMode = 'check';
+        let btnDisabled = false;
         switch (s.status) {
             case 'checking':
                 action = 'checking for updates…';
+                btnDisabled = true;
                 break;
             case 'downloading': {
                 const pct = typeof s.percent === 'number' ? s.percent : null;
                 action = pct === null ? 'update available — downloading…' : `downloading update… ${pct}%`;
+                btnDisabled = true;
                 break;
             }
             case 'downloaded':
-                action = 'update ready — restart to apply';
+                action = 'update ready';
+                if (typeof updateApi.apply === 'function') {
+                    btnLabel = 'Restart now';
+                    btnMode = 'restart';
+                } else {
+                    // Older bridge without apply(): fall back to text-only.
+                    action = 'update ready — restart to apply';
+                }
                 break;
             case 'error':
                 action = s.message ? `update error: ${s.message}` : 'update check failed';
@@ -302,6 +321,9 @@ export function setupAppUpdates() {
                 action = `up to date · last checked ${fmtTimestamp(s.lastChecked)}`;
                 break;
         }
+        checkBtn.textContent = btnLabel;
+        checkBtn.dataset.mode = btnMode;
+        checkBtn.disabled = btnDisabled;
         const line = `${base} · ${action}`;
         statusEl.textContent = extra ? `${extra} · ${line}` : line;
         // A download runs in the background (the check returns immediately), so
@@ -381,6 +403,26 @@ export function setupAppUpdates() {
         });
 
         checkBtn.addEventListener('click', async () => {
+            // In restart mode (set by renderFrom once an update is staged) the
+            // button applies the update instead of checking again.
+            if (checkBtn.dataset.mode === 'restart') {
+                checkBtn.disabled = true;
+                checkBtn.textContent = 'Restarting…';
+                try {
+                    const r = await updateApi.apply();
+                    if (r?.status === 'error') {
+                        console.warn('[updater] apply returned error:', r.message || 'unknown');
+                        renderFrom(r, 'Restart failed.');
+                    }
+                    // On success the app quits + relaunches — nothing to render.
+                } catch (e) {
+                    console.warn('[updater] apply failed:', e);
+                    statusEl.textContent = `Restart failed: ${e?.message || e}`;
+                    checkBtn.textContent = 'Restart now';
+                    checkBtn.disabled = false;
+                }
+                return;
+            }
             checkBtn.disabled = true;
             statusEl.textContent = 'Checking for updates…';
             let result;

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -368,11 +368,12 @@ export function setupAppUpdates() {
             if (!APP_UPDATE_CHANNELS.includes(val)) return;
             try { localStorage.setItem('feedBack-update-channel', val); localStorage.removeItem('slopsmith-update-channel'); } catch (_) {}
             try {
-                // Await setChannel so the status line reflects what actually
-                // happened — rendering "Channel set" unconditionally would
-                // mislead users when the IPC rejects.
-                await Promise.resolve(updateApi.setChannel(val));
-                renderStatus(`Channel set to ${val}.`);
+                // Render from setChannel()'s own return value (same reasoning
+                // as the check button: it's computed synchronously at the
+                // moment of the switch, so it can't be stale, unlike a
+                // follow-up getStatus() call).
+                const result = await Promise.resolve(updateApi.setChannel(val));
+                renderFrom(result, `Channel set to ${val}.`);
             } catch (e) {
                 console.warn('[updater] setChannel failed:', e);
                 renderStatus(`Failed to set channel to ${val}: ${e?.message || e}`);
@@ -382,19 +383,26 @@ export function setupAppUpdates() {
         checkBtn.addEventListener('click', async () => {
             checkBtn.disabled = true;
             statusEl.textContent = 'Checking for updates…';
+            let result;
             try {
                 // The Linux check returns immediately (any download runs in the
-                // background); we don't act on the returned status directly —
-                // renderStatus() below reads the authoritative state and starts
-                // the progress poll if a download is now under way.
-                await updateApi.checkNow();
+                // background).
+                result = await updateApi.checkNow();
             } catch (e) {
                 console.warn('[updater] checkNow failed:', e);
                 statusEl.textContent = `Update check failed: ${e?.message || e}`;
                 checkBtn.disabled = false;
                 return;
             }
-            renderStatus();
+            // Render straight from checkNow()'s own return value rather than a
+            // follow-up getStatus() call. checkNow() computes that value
+            // synchronously at the moment it decides the outcome, so it can't
+            // be stale; a separate getStatus() round-trip right after it can
+            // race with anything that resets state in between (a concurrent
+            // channel switch, another in-flight check settling) and show a
+            // blanked "up to date · last checked never" even though this check
+            // just succeeded.
+            renderFrom(result);
         });
 
         _appUpdatesWired = true;

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -275,6 +275,12 @@ export function setupAppUpdates() {
     // visible and appends what's happening, so the download progress never
     // obscures which build you're on.
     function renderFrom(s, extra) {
+        // Diagnostic trace: log the raw status object on EVERY render
+        // (unconditionally, before any branching) — auto-captured by
+        // diagnostics.js's console wrap into the exportable ring buffer, so
+        // "Export Diagnostics" in this same Settings → System panel captures
+        // exactly what the app saw and decided, not just what the UI showed.
+        console.log('[update-diag] renderFrom', JSON.stringify(s), extra ? `extra=${extra}` : '');
         if (!s) { statusEl.textContent = extra || 'Updater status unavailable.'; return; }
         if (s.status === 'unsupported' || s.platform === 'linux') {
             showLinuxFallback('Auto-update requires the AppImage build on the Nightly channel.');
@@ -326,6 +332,27 @@ export function setupAppUpdates() {
         checkBtn.disabled = btnDisabled;
         const line = `${base} · ${action}`;
         statusEl.textContent = extra ? `${extra} · ${line}` : line;
+
+        // Live structured snapshot (overwrites, not a log) via the existing
+        // diagnostics contribute() API — 'audio_engine' is feedBack-desktop's
+        // own registered plugin id, so the server's diagnostics export won't
+        // filter it out. Always current, no scrolling through console history
+        // needed to answer "what does the app think is going on right now."
+        try {
+            window.feedBack?.diagnostics?.contribute('audio_engine', {
+                update: {
+                    channel: s.channel || channelSelect.value,
+                    status: s.status,
+                    currentVersion: s.currentVersion ?? null,
+                    lastChecked: s.lastChecked ?? null,
+                    percent: typeof s.percent === 'number' ? s.percent : null,
+                    message: s.message ?? null,
+                    rendered: line,
+                    ts: Date.now(),
+                },
+            });
+        } catch (_) { /* diagnostics.js not loaded — never let this break rendering */ }
+
         // A download runs in the background (the check returns immediately), so
         // poll for the terminal state rather than relying solely on a one-shot
         // "downloaded" event that could be missed or arrive out of order.
@@ -388,6 +415,7 @@ export function setupAppUpdates() {
         channelSelect.addEventListener('change', async () => {
             const val = channelSelect.value;
             if (!APP_UPDATE_CHANNELS.includes(val)) return;
+            console.log('[update-diag] user switched channel to', val);
             try { localStorage.setItem('feedBack-update-channel', val); localStorage.removeItem('slopsmith-update-channel'); } catch (_) {}
             try {
                 // Render from setChannel()'s own return value (same reasoning
@@ -406,6 +434,7 @@ export function setupAppUpdates() {
             // In restart mode (set by renderFrom once an update is staged) the
             // button applies the update instead of checking again.
             if (checkBtn.dataset.mode === 'restart') {
+                console.log('[update-diag] user clicked Restart now');
                 checkBtn.disabled = true;
                 checkBtn.textContent = 'Restarting…';
                 try {
@@ -423,6 +452,7 @@ export function setupAppUpdates() {
                 }
                 return;
             }
+            console.log('[update-diag] user clicked Check for updates');
             checkBtn.disabled = true;
             statusEl.textContent = 'Checking for updates…';
             let result;
@@ -446,6 +476,15 @@ export function setupAppUpdates() {
             // just succeeded.
             renderFrom(result);
         });
+
+        // Main-process events (checkNow/download decisions in update-manager.ts)
+        // are invisible to this page's console — forward them into it so a
+        // single "Export Diagnostics" click captures both sides of the story.
+        if (typeof updateApi.onDiag === 'function') {
+            updateApi.onDiag((payload) => {
+                console.log('[update-diag:main]', payload?.message, payload?.data ? JSON.stringify(payload.data) : '');
+            });
+        }
 
         _appUpdatesWired = true;
     }

--- a/static/v3/index.html
+++ b/static/v3/index.html
@@ -741,6 +741,7 @@
                                 <option value="rc">Release candidate</option>
                                 <option value="beta">Beta</option>
                                 <option value="alpha">Alpha</option>
+                                <option value="nightly">Nightly</option>
                             </select>
                             <button id="app-update-check-now"
                                 class="bg-accent hover:bg-accent-light px-4 py-2.5 rounded-xl text-sm font-medium text-white transition disabled:opacity-50">
@@ -749,8 +750,8 @@
                         </div>
                         <p id="app-update-status" class="text-xs text-gray-500 fb-srow-wide">Loading updater status…</p>
                         <p id="app-update-linux-note" class="hidden text-xs text-yellow-300 fb-srow-wide">
-                            Auto-update is not available on Linux —
-                            <a href="https://github.com/got-feedback/feedback-desktop/releases" target="_blank" rel="noopener" class="text-accent hover:text-accent-light underline">download new versions from GitHub Releases</a>.
+                            Auto-update on Linux only works for the AppImage build on the Nightly channel —
+                            <a href="https://github.com/got-feedBack/feedBack-desktop/releases" target="_blank" rel="noopener" class="text-accent hover:text-accent-light underline">download other versions from GitHub Releases</a>.
                         </p>
                     </div>
                     <!-- Window options — desktop-only; setupWindowOptions() unhides. -->


### PR DESCRIPTION
## Summary
- Fixes the Settings → System "App updates" panel so it actually works on Linux: the channel dropdown no longer gets permanently disabled the moment the desktop bridge reports `unsupported` (which is the normal state whenever the channel isn't Nightly on Linux) — it stays enabled so the user can switch to Nightly, which is the only way out of that state.
- Adds Nightly to `APP_UPDATE_CHANNELS` and the channel `<select>` — previously missing entirely, so Linux self-update couldn't be reached from this UI at all.
- Shows live download progress ("Downloading update… N%") and an explicit state machine on the Check/Restart button, instead of a frozen "Checking…" during the ~1.5GB background download.
- Two real UI bugs found via on-device Export Diagnostics captures, both fixed: (1) `setupAppUpdates()` was re-syncing the channel on every Settings re-render, which could stomp an in-flight download's state; (2) the very first channel sync on page load raced against the initial status render and could get stuck showing "unsupported" even after the channel was correctly set.
- Routes update-flow logging into the existing `diagnostics.js` console-capture + `contribute()` snapshot API, so a user's existing "Export Diagnostics" button now captures the full update decision trace for future debugging — no new UI or log file.

Companion PR in feedBack-desktop (the underlying update engine): got-feedBack/feedBack-desktop#118

## Test plan
- [x] Every renderer change verified with a standalone browser harness (mocking `window.feedBackDesktop.update` and `window.feedBack.diagnostics`) reproducing the exact bug sequence before confirming the fix, for each of the fixes above.
- [x] Verified end-to-end on a Steam Deck: channel switch → check → live download progress → restart button → relaunch onto the new build, confirmed via a real Export Diagnostics capture showing a clean, fully-accounted-for trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)