### PR TITLE
feat(v3): one-click "Not split" library filter + piano stem pill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Library filter: one-click "Not split" + a piano stem pill.** The v3 Filters drawer's
+  stems section gains a **Not split** shortcut that selects "lacks every instrument stem"
+  in one tap — the same query Stem Splitter's missing-stems view runs — instead of
+  cycling five pills to ✕ by hand. The pill row also gains `piano` (the drawer offered
+  five of the canonical six stems, so a piano-only song wrongly matched a hand-built
+  "lacks all" filter). "No lyrics" already existed in the Lyrics section.
 - **Gold tier (career passports)** — an earned badge turns **gold** when
   Virtuoso verifies an improvised jam in the passport's style (the
   `gold_improv` artifact relays with the drill snapshot; a genre inherits its

--- a/static/v3/songs.js
+++ b/static/v3/songs.js
@@ -44,7 +44,7 @@
     ];
     const FORMATS = [['', 'All formats'], ['sloppak', 'Feedpak'], ['loose', 'Folder']];
     const ARRANGEMENTS = ['Lead', 'Rhythm', 'Bass', 'Combo', 'Vocals'];
-    const STEMS = ['guitar', 'bass', 'drums', 'vocals', 'other'];
+    const STEMS = ['guitar', 'bass', 'drums', 'vocals', 'piano', 'other'];
     const PAGE_SIZE = 24;
     // Extra rows rendered above/below the viewport so a fast scroll doesn't flash
     // blank before the next window render lands.
@@ -2940,7 +2940,17 @@
             '<div class="flex items-center justify-between"><h3 class="text-lg font-semibold text-fb-text">Filters</h3>' +
             '<button data-drawer-close class="text-fb-textDim hover:text-fb-text">✕</button></div>' +
             section('Arrangements', ARRANGEMENTS.map((a) => triPill('arr', a, a, triState(f.arr_has, f.arr_lacks, a))).join('')) +
-            section('Stems (feedpak)', STEMS.map((s) => triPill('stem', s, s, triState(f.stem_has, f.stem_lacks, s))).join('')) +
+            section('Stems (feedpak)', STEMS.map((s) => triPill('stem', s, s, triState(f.stem_has, f.stem_lacks, s))).join('') +
+                (() => {
+                    // One-click "which songs still need splitting": lacks EVERY
+                    // instrument stem — the same query Stem Splitter's own
+                    // missing-stems view runs. Toggles off if already active.
+                    const on = STEMS.every((s) => f.stem_lacks.includes(s)) && !f.stem_has.length;
+                    return '<button data-stem-unsplit class="px-2 py-1 rounded-md text-xs border '
+                        + (on ? 'bg-fb-primary text-white border-fb-primary' : 'bg-gray-800/50 text-fb-textDim border-gray-700')
+                        + '" title="Songs with no instrument stems — not yet split">'
+                        + (on ? '✕ ' : '') + 'Not split</button>';
+                })()) +
             section('Lyrics', ['', '1', '0'].map((v) => '<button data-lyrics="' + v + '" class="px-2 py-1 rounded-md text-xs border ' + (f.lyrics === v ? 'bg-fb-primary text-white border-fb-primary' : 'bg-gray-800/50 text-fb-textDim border-gray-700') + '">' + (v === '' ? 'Any' : v === '1' ? 'Has lyrics' : 'No lyrics') + '</button>').join('')) +
             // Progress (mastery bands) — multi-select; server filters via song_stats.
             section('Progress', [['mastered', 'Mastered'], ['in_progress', 'In progress'], ['not_started', 'Not started']].map((it) => '<button data-mastery="' + it[0] + '" class="px-2 py-1 rounded-md text-xs border ' + (f.mastery.includes(it[0]) ? 'bg-fb-primary text-white border-fb-primary' : 'bg-gray-800/50 text-fb-textDim border-gray-700') + '">' + it[1] + '</button>').join('')) +
@@ -3032,6 +3042,13 @@
             f.tuningMatch = b.getAttribute('data-tuning-match');
             renderDrawer();
         }));
+        d.querySelector('[data-stem-unsplit]')?.addEventListener('click', () => {
+            const on = STEMS.every((s) => f.stem_lacks.includes(s)) && !f.stem_has.length;
+            f.stem_has.length = 0;
+            f.stem_lacks.length = 0;
+            if (!on) f.stem_lacks.push(...STEMS);
+            renderDrawer();
+        });
         d.querySelectorAll('[data-lyrics]').forEach((b) => b.addEventListener('click', () => { f.lyrics = b.getAttribute('data-lyrics'); renderDrawer(); }));
         d.querySelectorAll('[data-mastery]').forEach((b) => b.addEventListener('click', () => { const v = b.getAttribute('data-mastery'); const i = f.mastery.indexOf(v); if (i >= 0) f.mastery.splice(i, 1); else f.mastery.push(v); renderDrawer(); }));
         d.querySelector('[data-grouping]')?.addEventListener('click', () => {


### PR DESCRIPTION
From a user question — "can I filter for songs with no stems or no lyrics?" No-lyrics already exists in the Filters drawer; not-split was possible but took five taps and was quietly wrong.

- **"Not split" shortcut** in the stems section: one tap sets `stems_lacks` to every instrument stem — the same lacks-ALL query Stem Splitter's own missing-stems view runs. Toggles off if already active; any manual pill change simply replaces the state (the shortcut is just a preset, not a mode).
- **`piano` joins the pill row.** The drawer offered five of the canonical six stems, so a piano-only song lacked all five listed and wrongly matched a hand-built "lacks everything" filter. Backend already allows `piano` (`_ALLOWED_STEM_IDS`), so this is UI-only.

No backend changes; existing `stems_lacks` semantics (`NOT EXISTS … IN (…)` = lacks all listed) do the work. Existing v3 songs tests pass (7/7). Uses only utility classes already present in the drawer, so no Tailwind rebuild.

**Verified on screen** by the maintainer — drawer styling and toggle behaviour confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a one-tap **“Not split”** shortcut to the stems section of the v3 Library Filters drawer.
  - Added a **piano** stem filter pill.

- **Bug Fixes**
  - Corrected one-tap stem selection behavior.
  - Fixed piano-only matching so results accurately reflect the selected filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->