### PR TITLE
Pass per-stem name/description through to the stems payloads

### DIFF
--- a/lib/routers/song.py
+++ b/lib/routers/song.py
@@ -868,7 +868,8 @@ def _playable_stems_payload(filename: str, dlc) -> dict:
 
     return {
         "stems": [
-            {"id": s["id"], "url": _url(s["file"]), "default": s["default"]}
+            {"id": s["id"], "url": _url(s["file"]), "default": s["default"],
+             **{k: s[k] for k in ("name", "description") if k in s}}
             for s in loaded.stems
         ],
         "full_mix_url": _url(loaded.full_mix) if loaded.full_mix else None,

--- a/lib/routers/ws_highway.py
+++ b/lib/routers/ws_highway.py
@@ -368,7 +368,9 @@ async def highway_ws(websocket: WebSocket, filename: str, arrangement: int = -1,
             q_fn = quote(filename, safe="")
             for s in loaded_slop.stems:
                 url = f"/api/sloppak/{q_fn}/file/{quote(s['file'])}"
-                stems_payload.append({"id": s["id"], "url": url, "default": s["default"]})
+                stems_payload.append(
+                    {"id": s["id"], "url": url, "default": s["default"],
+                     **{k: s[k] for k in ("name", "description") if k in s}})
             # Full-mix URL (served by the same /api/sloppak/.../file/ endpoint).
             if loaded_slop is not None and loaded_slop.full_mix:
                 full_mix_url = (

--- a/lib/sloppak.py
+++ b/lib/sloppak.py
@@ -1114,11 +1114,19 @@ def load_song(
         sfile = str(s.get("file", ""))
         if not sid or not sfile:
             continue
-        stems.append({
+        entry = {
             "id": sid,
             "file": sfile,
             "default": stem_default_on(s.get("default", True)),
-        })
+        }
+        # Optional presentational fields (feedpak 1.16.0, spec §5.3). Omitted —
+        # not None — when absent, so payload builders can pass entries through
+        # without every stem growing null keys.
+        for key in ("name", "description"):
+            val = s.get(key)
+            if isinstance(val, str) and val.strip():
+                entry[key] = val
+        stems.append(entry)
 
     # The complete mixdown is a stem (spec §5.3), but it is not a *layer*: lift
     # it out so that no consumer of `stems` — the mixer, the library's stem

--- a/tests/test_song_info_stems.py
+++ b/tests/test_song_info_stems.py
@@ -59,7 +59,8 @@ def _ws_payload(tmp_path, pak):
     return {
         "stems": [
             {"id": s["id"], "url": f"/api/sloppak/{q}/file/{quote(s['file'])}",
-             "default": s["default"]}
+             "default": s["default"],
+             **{k: s[k] for k in ("name", "description") if k in s}}
             for s in loaded.stems
         ],
         "full_mix_url": f"/api/sloppak/{q}/file/{quote(loaded.full_mix)}" if loaded.full_mix else None,
@@ -126,6 +127,33 @@ def test_rest_matches_the_ws_for_a_single_full_pack(tmp_path):
     assert rest == _ws_payload(tmp_path, pak)
     assert [s["id"] for s in rest["stems"]] == ["full"]
     assert rest["full_mix_url"] is None
+
+
+def test_stem_name_and_description_pass_through(tmp_path):
+    """feedpak 1.16.0 per-stem `name`/`description` (spec §5.3) reach the payload.
+
+    Presentational, so the rule is passthrough-or-omit: a stem that carries the
+    fields keeps them, a stem that doesn't must NOT grow null keys, and
+    non-string / blank values are dropped rather than surfaced.
+    """
+    pak = _pak(tmp_path, [
+        {"id": "guitar", "file": "stems/guitar.ogg", "name": "Rhythm Guitar"},
+        {"id": "click", "file": "stems/click.ogg", "name": "Click",
+         "description": "Metronome click with 4-count lead-in.", "default": "off"},
+        {"id": "bass", "file": "stems/bass.ogg"},
+        {"id": "junk", "file": "stems/junk.ogg", "name": 7, "description": "   "},
+    ], name="Labelled.feedpak")
+
+    rest = _payload(tmp_path, pak)
+    assert rest == _ws_payload(tmp_path, pak)
+    by_id = {s["id"]: s for s in rest["stems"]}
+    assert by_id["guitar"]["name"] == "Rhythm Guitar"
+    assert "description" not in by_id["guitar"]
+    assert by_id["click"]["name"] == "Click"
+    assert by_id["click"]["description"] == "Metronome click with 4-count lead-in."
+    assert by_id["click"]["default"] is False
+    assert "name" not in by_id["bass"] and "description" not in by_id["bass"]
+    assert "name" not in by_id["junk"] and "description" not in by_id["junk"]
 
 
 def test_a_broken_pack_yields_an_empty_list_not_an_error(tmp_path):


### PR DESCRIPTION
Part 1 of 3 for per-stem display metadata (feedpak 1.16.0, spec §5.3 `name`/`description` —
got-feedback/feedpak-spec#59): the server currently drops both fields while normalizing
manifest stems, so no client can display them.

## What

- `sloppak.load_song` stem descriptors keep `name`/`description` when the manifest carries
  them (omit-when-absent — no null keys; non-string/blank values dropped).
- Both payload builders pass them through: WS `ready` stems list (`ws_highway.py`) and REST
  `/api/song/{f}?stems=1` preload list (`song.py`). The two stay pinned against each other by
  `test_song_info_stems.py`, whose mirror is updated and which gains a passthrough test.

## Compatibility

Additive. Every consumer reading `{id, url, default}` is unchanged; stems without the fields
serialize exactly as before.

## Follow-ups

- stems plugin: forward the fields in `stems:state` / `getState()`
- stem_mixer: display `name` (fallback: built-in label → capitalized id) + description tooltip

## Verification

- `pytest tests/test_song_info_stems.py` — 6 passed (incl. new passthrough test)
- Full suite: 2689 passed; 8 failures are pre-existing local-env issues (Windows symlink
  privilege, tailwind runtime config) — identical failures on the unmodified tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
