### PR TITLE
fix(sloppak/ws_highway): drums stay in picker and show correct hit count

### DIFF
--- a/lib/routers/ws_highway.py
+++ b/lib/routers/ws_highway.py
@@ -478,12 +478,24 @@ async def highway_ws(websocket: WebSocket, filename: str, arrangement: int = -1,
             _evict_audio_cache()
 
         # Send song metadata
+        # For drum-only sloppaks the placeholder arrangement has 0 notes
+        # (drum_tab hits live separately).  Surface the real hit count so
+        # the UI shows e.g. "Drums (1922)" instead of "Drums (0)".
+        _DRUM_KEYWORDS = ("drum", "percussion")
+        _dt_hit_count = 0
+        if is_slop and loaded_slop is not None and loaded_slop.drum_tab is not None:
+            _dt_hit_count = len(loaded_slop.drum_tab.get("hits") or [])
         arr_list = [
             {
                 "index": i,
                 "name": a.name,
                 "smart_name": smart_names[i],
-                "notes": len(a.notes) + sum(len(c.notes) for c in a.chords),
+                "notes": (
+                    _dt_hit_count
+                    if (len(a.notes) == 0 and not a.chords and _dt_hit_count > 0
+                        and any(kw in (a.name or "").lower() for kw in _DRUM_KEYWORDS))
+                    else len(a.notes) + sum(len(c.notes) for c in a.chords)
+                ),
             }
             for i, a in enumerate(song.arrangements)
         ]

--- a/lib/sloppak.py
+++ b/lib/sloppak.py
@@ -895,16 +895,21 @@ def load_song(
                     log.warning("sloppak: drum_tab %r failed validation: %s",
                                 drum_tab_rel, reason)
 
-    # Drum-only sloppak: every GP track was percussion, so it ships a
-    # drum_tab but no pitched arrangements. The highway WS rejects an empty
-    # arrangements list with "No arrangements found" *before* it serves the
-    # drum_tab, leaving the drums unplayable even in the drum highway.
-    # Synthesize a minimal placeholder arrangement so the stream proceeds and
-    # the drum_tab reaches the drum highway. It carries no notes (the guitar
-    # highway just shows an empty board) and, when the manifest omits a
+    # Drum sloppak: when a drum_tab is present but no existing arrangement is
+    # a drum part, synthesize a minimal placeholder so the drums appear in the
+    # arrangement picker and the drum_tab reaches the drum highway.  The editor
+    # strips drum arrangements out of the manifest (converting them to
+    # drum_tab), so without this a drum+bass sloppak would show only Bass in
+    # the picker with no way to reach the drums.  It carries no notes (the
+    # guitar highway just shows an empty board) and, when the manifest omits a
     # duration, derives a song length from the last drum hit so the timeline
     # isn't zero-length.
-    if not song.arrangements and drum_tab_data is not None:
+    _DRUM_KEYWORDS = ("drum", "percussion")
+    _has_drum_arr = any(
+        any(kw in (getattr(a, "name", "") or "").lower() for kw in _DRUM_KEYWORDS)
+        for a in song.arrangements
+    )
+    if not _has_drum_arr and drum_tab_data is not None:
         if song.song_length <= 0:
             # validate_drum_tab() intentionally does NOT type-check individual
             # hits (they're sanitized at WS-stream time), so a hit may carry a


### PR DESCRIPTION
What

Fixes drums disappearing from the arrangement picker when imported alongside other instruments (e.g. bass), and shows the correct note count instead of "Drums (0)".

The editor strips drum arrangements from the manifest and converts them to drum_tab.json, so a saved drum+bass sloppak has no drum arrangement — only bass plus a drum_tab. The sloppak loader's placeholder-creation trigger was "arrangements list is empty", which only fired for drum-only packs. Broadened to "no drum arrangement exists" so drums get a placeholder even when other instruments are present. The placeholder arrangement also now displays the actual drum_tab hit count instead of 0.

feedpak surface
- This PR does not change how the app reads/writes feedpaks (manifest keys, pack files, folder layout)

Checklist
- CHANGELOG.md [Unreleased] updated (user-visible changes)
- Tests added/updated for new behaviour
- Commits are DCO signed off (git commit -s)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured drum tab data results in a “Drums” placeholder arrangement when no existing drum/percussion arrangement is present.
  * Fixed displayed note counts for drum-only arrangements to match the underlying drum hit totals.
  * Improved song duration calculation when duration metadata is missing/invalid by deriving it from available drum timing information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->