### PR TITLE
refactor(sloppak): route the rigs loader through the shared path helper

### DIFF
--- a/lib/sloppak.py
+++ b/lib/sloppak.py
@@ -816,16 +816,8 @@ def _load_rigs_file(source_dir: Path, rel: str) -> dict | None:
     realization selection and the `intent.gm` fallback belong to whatever
     voices the part.
     """
-    try:
-        r_path = (source_dir / rel).resolve()
-        r_path.relative_to(source_dir.resolve())
-    except ValueError:
-        log.warning("sloppak: rigs path %r escapes source_dir — skipped", rel)
-        return None
-    except OSError as e:
-        log.warning("sloppak: rigs path resolution failed (%s) — skipped", e)
-        return None
-    if not r_path.exists():
+    r_path = _resolve_pack_path(source_dir, rel, "rigs")
+    if r_path is None or not r_path.exists():
         return None
     try:
         raw = load_json(r_path)


### PR DESCRIPTION
## What

Follow-up promised in #1040. `_load_rigs_file` is currently the only loader in `lib/sloppak.py` still open-coding the manifest-path containment guard — its seven siblings go through `_resolve_pack_path`.

#1039 (the dedup) and #1040 (the rig reader) were each correct against the base they were written on, and merged in the right order. #1040 just went in without the rebase that would have joined them, leaving the eighth call site behind. Two lines in place of ten.

## Verification

- Full suite **2796 passed / 4 skipped**, unchanged.
- Rendered log output identical — triggered a traversal through the new path and confirmed `sloppak: rigs path '../outside.json' escapes source_dir — skipped`, byte-for-byte what the inline copy emitted.
- Existing coverage carries it: `test_sloppak_rigs_load.py::test_load_song_rejects_traversing_rigs_path` already exercises this exact path.

No behaviour change, no new validation.

## feedpak surface

- [x] This PR does **not** change how the app reads/writes feedpaks (manifest keys, pack files, folder layout)

## Checklist

- [x] `CHANGELOG.md` `[Unreleased]` updated — n/a, internal refactor with no user-visible change
- [x] Tests added/updated for new behaviour — n/a, no new behaviour; existing traversal test is the check
- [x] Commits are DCO signed off (`git commit -s`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rig manifest paths.
  * Invalid or missing rig files are now safely ignored, preventing loading errors and disabling rigs when necessary.
  * Path validation is applied consistently for packaged and archive-based content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->